### PR TITLE
replace dashes with underscores

### DIFF
--- a/docs/contracts/tutorial/interacting.md
+++ b/docs/contracts/tutorial/interacting.md
@@ -31,7 +31,7 @@ satisfy adjust timber high purchase tuition stool faith fine install that you un
 
 ## Uploading Code
 
-Make sure that the **optimized build** of `my-first-contract.wasm` that you created in the last section is in your current working directory.
+Make sure that the **optimized build** of `my_first_contract.wasm` that you created in the last section is in your current working directory.
 
 ```sh
 terracli tx wasm store my-first-contract.wasm --from test1 --chain-id=localterra --gas=auto --fees=100000uluna --broadcast-mode=block


### PR DESCRIPTION
after running the provided docker command, the optimized wasm file is called `my_first_contract.wasm`, not `my-first-contract.wasm`