### PR TITLE
Fix git clone url in Installation docs.

### DIFF
--- a/docs/node/installation.md
+++ b/docs/node/installation.md
@@ -23,7 +23,7 @@ If you haven't already, install Golang by following the [official docs](https://
 Use `git` to retrieve Terra Core from the [official repo](https://github.com/terra-project/core/), and checkout the `master` branch, which contains the latest stable release. That should install the `terrad` and `terracli` binaries.
 
 ```bash
-git clone https://github.com/terra-project/core/
+git clone https://github.com/terra-project/core
 cd core
 git checkout master
 ```


### PR DESCRIPTION
Fixes:

```
git clone https://github.com/terra-project/core/
Cloning into 'core'...
ERROR: Repository not found.
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```