### PR TITLE
Updating 100 validators to 130 validators

### DIFF
--- a/docs/dev/spec-staking.md
+++ b/docs/dev/spec-staking.md
@@ -263,7 +263,7 @@ Time duration of unbonding, in nanoseconds.
 ### MaxValidators
 
 - type: `uint16`
-- default: `100`
+- default: `130`
 
 Maximum number of active validators.
 

--- a/docs/validators.md
+++ b/docs/validators.md
@@ -14,7 +14,7 @@ A validator's **voting power** is proportional to the amount of Luna they have b
 
 ### Slashing Risks
 
-Running validator is a big responsibility, which is why only the top 100 in bonded Luna stake are elected to sign blocks. As such, safety and liveness guarantees must be met, at the risk of having their validator's stake slashed (penalized), hurting both the validator's funds (as well as their delegator's), and their reputation.
+Running validator is a big responsibility, which is why only the top 130 in bonded Luna stake are elected to sign blocks. As such, safety and liveness guarantees must be met, at the risk of having their validator's stake slashed (penalized), hurting both the validator's funds (as well as their delegator's), and their reputation.
 
 The major slashing conditions are:
 

--- a/docs/validators.md
+++ b/docs/validators.md
@@ -10,7 +10,7 @@ Validators play a central role in the Terra blockchain's consensus, which is bas
 
 In Terra's consensus model, Luna holders do not stake their tokens directly, but **delegate** their Luna to a validator. This allows normal Luna holders who don't want to set up a validator node can participate in staking rewards.
 
-A validator's **voting power** is proportional to the amount of Luna they have bonded, from all delegations (including their self-delegation). Only the **top 100** validators in voting power (and bonded Luna, by corollary) comprise the validating set, referred to hereon as **delegates**. Delegators play a vital role in this ecosystem because they determine which validators receive this designation, voting by delegating their Luna.
+A validator's **voting power** is proportional to the amount of Luna they have bonded, from all delegations (including their self-delegation). Only the **top 130** validators in voting power (and bonded Luna, by corollary) comprise the validating set, referred to hereon as **delegates**. Delegators play a vital role in this ecosystem because they determine which validators receive this designation, voting by delegating their Luna.
 
 ### Slashing Risks
 


### PR DESCRIPTION
https://lcd.terra.dev/staking/parameters returns ""max_validators": 130". Updating this in docs.

Concepts page describing delegation and slashing risks still mentions only 100 validators in two places. Updated that as well.