### PR TITLE
Updated doc to checkout localterra v0.4.1 tag

### DIFF
--- a/docs/contracts/tutorial/setup.md
+++ b/docs/contracts/tutorial/setup.md
@@ -15,7 +15,7 @@ In this tutorial, we will be using [LocalTerra](https://github.com/terra-money/l
 To use **LocalTerra**, you should first make sure Docker is installed on your computer by following the instructions [here](https://www.docker.com/get-started). You will also need to set up and configure [Docker Compose](https://docs.docker.com/compose/install/) on your machine.
 
 ```sh
-git clone https://github.com/terra-money/localterra
+git clone --branch v0.4.1 --depth 1 https://github.com/terra-money/localterra
 cd localterra
 docker-compose up
 ```


### PR DESCRIPTION
The current tutorial 'my-first-contract' is incompatible with the current localterra github main branch. I tried using the latest cosmwasm template version without any more success. 

When trying to deploy I'm always running into this error:
```Error: rpc error: code = InvalidArgument desc = failed to execute message; message index: 0: Error calling the VM: Error during static Wasm validation: Wasm contract doesn't have required export: "interface_version_6". Exports required by VM: ["interface_version_6", "instantiate", "allocate", "deallocate"]. Contract version too old for this VM?: store wasm contract failed: invalid request```

The only way I could make it work is by using the localterra docker-compose from v0.4.1
So, until everything is working with columbus-5, I think the tutorial should stick to the working version of localterra to avoid scaring away new developers