### PR TITLE
Update localterra version to use v0.4.1

### DIFF
--- a/docs/contracts/tutorial/setup.md
+++ b/docs/contracts/tutorial/setup.md
@@ -15,7 +15,7 @@ In this tutorial, we will be using [LocalTerra](https://github.com/terra-money/l
 To use **LocalTerra**, you should first make sure Docker is installed on your computer by following the instructions [here](https://www.docker.com/get-started). You will also need to set up and configure [Docker Compose](https://docs.docker.com/compose/install/) on your machine.
 
 ```sh
-git clone https://github.com/terra-money/localterra
+git clone --branch v0.4.1 --depth 1 https://github.com/terra-money/localterra.git
 cd localterra
 docker-compose up
 ```


### PR DESCRIPTION
Main branch is incompatible with the remaining of the tutorial since it's already using bombay colombus-5 testnet version. This should be using colombus-4 localterra until colombus-5 is released on mainnet.