### PR TITLE
add relative URL for [joining an existing network] link

### DIFF
--- a/docs/node/testnet.md
+++ b/docs/node/testnet.md
@@ -1,6 +1,6 @@
 # Running a Local Testnet
 
-After you've gotten the latest version of Terra Core installed, you can set up a private Terra network to get your bearings in running a Terra full node before [joining an existing network]().
+After you've gotten the latest version of Terra Core installed, you can set up a private Terra network to get your bearings in running a Terra full node before [joining an existing network](join-network.md).
 
 ## Single Node Setup
 


### PR DESCRIPTION
Link in md was missing, so it was just link to the same page

https://stackoverflow.com/questions/7653483/github-relative-link-in-markdown-file/7658676 hint to use .md filename as URL