### PR TITLE
Update Treasury modules for seigniorage burn

### DIFF
--- a/docs/dev/spec-treasury.md
+++ b/docs/dev/spec-treasury.md
@@ -7,7 +7,7 @@ sidebarDepth: 2
 The Treasury module acts as the "central bank" of the Terra economy, measuring macroeconomic activity by [observing indicators](#observed-indicators) and adjusting [monetary policy levers](#monetary-policy-levers) to modulate miner incentives toward stable, long-term growth.
 
 ::: tip Note:
-While the Treasury stabilizes miner demand through adjusting rewards, the [`Market` module](spec-market.md) is responsible for Terra's price-stability through arbitrage and Terra's market-maker.
+While the Treasury stabilizes miner demand through adjusting rewards, the [`Market` module](spec-market.md) maintains Terra's price-stability through arbitrage and Terra's market-maker.
 :::
 
 ## Concepts
@@ -32,9 +32,9 @@ The protocol can compute and compare the short-term ([`WindowShort`](#windowshor
 
 ### Monetary Policy Levers
 
-- **Tax Rate**: $r$, adjusts the amount of income coming from Terra transactions, limited by [_tax cap_](#tax-caps).
+- **Tax Rate**: $r$, adjusts the amount of income gained from Terra transactions, limited by [_tax cap_](#tax-caps).
 
-- **Reward Weight**: $w$, the portion of seigniorage allocated to the reward pool for [`Oracle`](spec-oracle.md) vote winners who vote within the reward band of the weighted median exchange rate.
+- **Reward Weight**: $w$, the portion of seigniorage allocated to the reward pool for [`Oracle`](spec-oracle.md) vote winners. This is given to validtors who vote within the reward band of the weighted median exchange rate.
 
 ::: warning Note:
 As of Columbus-5, all seigniorage is burned and no longer funds the community pool or the oracle reward pool. Validators are instead rewarded for faithful oracle votes through swap fees.
@@ -42,7 +42,7 @@ As of Columbus-5, all seigniorage is burned and no longer funds the community po
 
 ### Updating Policies
 
-Both [Tax Rate](#tax-rate) and [Reward Weight](#reward-weight) are stored as values in the `KVStore`, and can have their values updated through [governance proposals](#governance-proposals) once passed. The Treasury will also re-calibrate each lever once per epoch to stabilize unit returns for Luna, thereby ensuring predictable mining rewards from staking:
+Both [Tax Rate](#tax-rate) and [Reward Weight](#reward-weight) are stored as values in the `KVStore` and can have their values updated through [governance proposals](#governance-proposals) after they have passed. The Treasury recalibrates each lever once per epoch to stabilize unit returns for Luna, ensuring predictable mining rewards from staking:
 
 - For Tax Rate, in order to make sure that unit mining rewards do not stay stagnant, the treasury adds a [`MiningIncrement`](#miningincrement) so mining rewards increase steadily over time, described [here](#kupdatetaxpolicy).
 

--- a/docs/dev/spec-treasury.md
+++ b/docs/dev/spec-treasury.md
@@ -14,7 +14,7 @@ While the Treasury stabilizes miner demand through adjusting rewards, the [`Mark
 
 ### Observed Indicators
 
-The Treasury observes three macroeconomic indicators for each epoch (set to 1 week) and keeps [historical records](#indicators) of their values during previous epochs:
+The Treasury observes three macroeconomic indicators for each epoch and keeps [indicators](#indicators) of their values during previous epochs:
 
 - **Tax Rewards**: $T$, the income generated from transaction and stability fees during an epoch.
 - **Seigniorage Rewards***: $S$, the amount of seigniorage generated from Luna swaps to Terra during an epoch which is destined for ballot rewards inside the `Oracle` rewards. As of Columbus-5, all seigniorage is burned.
@@ -37,7 +37,7 @@ The protocol can compute and compare the short-term ([`WindowShort`](#windowshor
 - **Reward Weight**: $w$, the portion of seigniorage allocated to the reward pool for [`Oracle`](spec-oracle.md) vote winners. This is given to validtors who vote within the reward band of the weighted median exchange rate.
 
 ::: warning Note:
-As of Columbus-5, all seigniorage is burned and no longer funds the community pool or the oracle reward pool. Validators are instead rewarded for faithful oracle votes through swap fees.
+As of Columbus-5, all seigniorage is burned and no longer funds the community pool or the oracle reward pool. Validators are rewarded for faithful oracle votes through swap fees.
 :::
 
 ### Updating Policies
@@ -46,7 +46,7 @@ Both [Tax Rate](#tax-rate) and [Reward Weight](#reward-weight) are stored as val
 
 - For Tax Rate, in order to make sure that unit mining rewards do not stay stagnant, the treasury adds a [`MiningIncrement`](#miningincrement) so mining rewards increase steadily over time, described [here](#kupdatetaxpolicy).
 
-- For Reward Weight, the Treasury observes the portion of seigniorage needed to bear the overall reward profile, [`SeigniorageBurdenTarget`](#seigniorageburdentarget), and raises rates accordingly, as described [here](#k-updaterewardpolicy). The current Reward Weight is 100%.
+- For Reward Weight, the Treasury observes the portion of seigniorage needed to bear the overall reward profile, [`SeigniorageBurdenTarget`](#seigniorageburdentarget), and raises rates accordingly, as described [here](#k-updaterewardpolicy). The current Reward Weight is `1`.
 
 ### Probation
 
@@ -108,7 +108,7 @@ type TaxRateUpdateProposal struct {
 ```
 
 ::: warning Note:
-As of Columbus-5, all seigniorage is burned. The Reward Weight is now set to 100%.
+As of Columbus-5, all seigniorage is burned. The Reward Weight is now set to `1`.
 :::
 
 ## State
@@ -116,17 +116,17 @@ As of Columbus-5, all seigniorage is burned. The Reward Weight is now set to 100
 ### Tax Rate
 
 - type: `Dec`
-- current min: .1%
-- current max: 1%
+- min: .1%
+- max: 1%
 
 The value of the Tax Rate policy lever for the current epoch.
 
 ### Reward Weight
 
 - type: `Dec`
-- current: 100%
+- default: `1`
 
-The value of the Reward Weight policy lever for the current epoch. As of Columbus-5, the reward weight is set to 100%.
+The value of the Reward Weight policy lever for the current epoch. As of Columbus-5, the reward weight is set to `1`.
 
 ### Tax Caps
 
@@ -256,7 +256,7 @@ This function is called at the end of an epoch to compute seigniorage and forwar
 3. The remainder of the coins $\Sigma - S$ is sent to the [`Distribution`](spec-distribution.md) module, where it is allocated into the community pool.
 
 ::: warning Note:
-As of Columbus-5, all seigniorage is burned and no longer funds the community pool or the oracle reward pool. Validators are instead rewarded for faithful oracle votes through swap fees.
+As of Columbus-5, all seigniorage is burned and no longer funds the community pool or the oracle reward pool. Validators are rewarded for faithful oracle votes through swap fees.
 :::
 
 ## Transitions

--- a/docs/dev/spec-treasury.md
+++ b/docs/dev/spec-treasury.md
@@ -16,13 +16,13 @@ While the Treasury stabilizes miner demand through adjusting rewards, the [`Mark
 
 The Treasury observes three macroeconomic indicators for each epoch (set to 1 week) and keeps [historical records](#indicators) of their values during previous epochs:
 
-- **Tax Rewards**: $T$, The income generated from transaction fees (stability fee) during an epoch.
-- **Seigniorage Rewards***: $S$, The amount of seigniorage generated from Luna swaps to Terra during an epoch which is destined for ballot rewards inside the `Oracle` rewards. As of Columbus-5, all seigniorage is burned.
-- **Total Staked Luna**: $\lambda$, The total amount of Luna staked by users and bonded to their delegated validators.
+- **Tax Rewards**: $T$, the income generated from transaction fees (stability fee) during an epoch.
+- **Seigniorage Rewards***: $S$, the amount of seigniorage generated from Luna swaps to Terra during an epoch which is destined for ballot rewards inside the `Oracle` rewards. As of Columbus-5, all seigniorage is burned.
+- **Total Staked Luna**: $\lambda$, the total amount of Luna staked by users and bonded to their delegated validators.
 
 These indicators are used to derive two other values:
-- **Tax Reward per unit Luna** $\tau = T / \lambda$: This is used in [Updating Tax Rate](#k-updatetaxpolicy)
-- **Total mining rewards** $R = T + S$: The sum of the Tax Rewards and the Seigniorage Rewards, used in [Updating Reward Weight](#k-updaterewardpolicy).
+- **Tax Reward per unit Luna** $\tau = T / \lambda$: this is used in [Updating Tax Rate](#k-updatetaxpolicy)
+- **Total mining rewards** $R = T + S$: the sum of the Tax Rewards and the Seigniorage Rewards, used in [Updating Reward Weight](#k-updaterewardpolicy).
 
 ::: warning Note:
 As of Columbus-5, all seigniorage is burned.
@@ -32,9 +32,9 @@ The protocol can compute and compare the short-term ([`WindowShort`](#windowshor
 
 ### Monetary Policy Levers
 
-- **Tax Rate**: $r$ This Adjusts the amount of income coming from Terra transactions, limited by [_tax cap_](#tax-caps).
+- **Tax Rate**: $r$, this adjusts the amount of income coming from Terra transactions, limited by [_tax cap_](#tax-caps).
 
-- **Reward Weight**: $w$ The portion of seigniorage allocated to the reward pool for ballot winners who vote within the reward band of the weighted median exchange rate in the [`Oracle`](spec-oracle.md) module.
+- **Reward Weight**: $w$, the portion of seigniorage allocated to the reward pool for ballot winners who vote within the reward band of the weighted median exchange rate in the [`Oracle`](spec-oracle.md) module.
 
 ::: warning Note:
 As of Columbus-5, all seigniorage is burned and no longer funds the community pool or the oracle reward pool. Validators are instead rewarded for faithful oracle votes through swap fees.
@@ -46,7 +46,7 @@ Both [Tax Rate](#tax-rate) and [Reward Weight](#reward-weight) are stored as val
 
 - For Tax Rate, in order to make sure that unit mining rewards do not stay stagnant, the treasury adds a [`MiningIncrement`](#miningincrement) so mining rewards increase steadily over time, described [here](#kupdatetaxpolicy).
 
-- For Reward Weight, The Treasury observes the portion of burden seigniorage needed to bear the overall reward profile, [`SeigniorageBurdenTarget`](#seigniorageburdentarget), and hikes up rates accordingly, described [here](#k-updaterewardpolicy). The current Reward Weight is `1`.
+- For Reward Weight, The Treasury observes the portion of burden seigniorage needed to bear the overall reward profile, [`SeigniorageBurdenTarget`](#seigniorageburdentarget), and hikes up rates accordingly, described [here](#k-updaterewardpolicy). The current Reward Weight is 100%.
 
 ### Probation
 
@@ -133,7 +133,7 @@ type RewardWeightUpdateProposal struct {
 :::
 
 ::: warning Note:
-As of Columbus-5, all seigniorage is burned. The reward weight is now set to `1`.
+As of Columbus-5, all seigniorage is burned. The Reward Weight is now set to 100%.
 :::
 
 ## State
@@ -141,14 +141,15 @@ As of Columbus-5, all seigniorage is burned. The reward weight is now set to `1`
 ### Tax Rate
 
 - type: `Dec`
-- default: 0.1%
+- Current min: .1%
+- Current max: 1%
 
 The value of the Tax Rate policy lever for the current epoch.
 
 ### Reward Weight
 
 - type: `Dec`
-- default: 5%
+- current: 100%
 
 The value of the Reward Weight policy lever for the current epoch. As of Columbus-5, the reward weight is set to `1`.
 

--- a/docs/dev/spec-treasury.md
+++ b/docs/dev/spec-treasury.md
@@ -16,7 +16,7 @@ While the Treasury stabilizes miner demand through adjusting rewards, the [`Mark
 
 The Treasury observes three macroeconomic indicators for each epoch (set to 1 week) and keeps [historical records](#indicators) of their values during previous epochs:
 
-- **Tax Rewards**: $T$, the income generated from transaction fees (stability fee) during an epoch.
+- **Tax Rewards**: $T$, the income generated from transaction and stability fees during an epoch.
 - **Seigniorage Rewards***: $S$, the amount of seigniorage generated from Luna swaps to Terra during an epoch which is destined for ballot rewards inside the `Oracle` rewards. As of Columbus-5, all seigniorage is burned.
 - **Total Staked Luna**: $\lambda$, the total amount of Luna staked by users and bonded to their delegated validators.
 
@@ -25,16 +25,16 @@ These indicators are used to derive two other values:
 - **Total mining rewards** $R = T + S$: the sum of the Tax Rewards and the Seigniorage Rewards, used in [Updating Reward Weight](#k-updaterewardpolicy).
 
 ::: warning Note:
-As of Columbus-5, all seigniorage is burned.
+As of Columbus-5, all seigniorage is burned and no longer funds community or reward pools.
 :::
 
 The protocol can compute and compare the short-term ([`WindowShort`](#windowshort)) and long-term ([`WindowLong`](#windowlong)) rolling averages of the above indicators to determine the relative direction and velocity of the Terra economy.
 
 ### Monetary Policy Levers
 
-- **Tax Rate**: $r$, this adjusts the amount of income coming from Terra transactions, limited by [_tax cap_](#tax-caps).
+- **Tax Rate**: $r$, adjusts the amount of income coming from Terra transactions, limited by [_tax cap_](#tax-caps).
 
-- **Reward Weight**: $w$, the portion of seigniorage allocated to the reward pool for ballot winners who vote within the reward band of the weighted median exchange rate in the [`Oracle`](spec-oracle.md) module.
+- **Reward Weight**: $w$, the portion of seigniorage allocated to the reward pool for [`Oracle`](spec-oracle.md) vote winners who vote within the reward band of the weighted median exchange rate.
 
 ::: warning Note:
 As of Columbus-5, all seigniorage is burned and no longer funds the community pool or the oracle reward pool. Validators are instead rewarded for faithful oracle votes through swap fees.
@@ -46,17 +46,17 @@ Both [Tax Rate](#tax-rate) and [Reward Weight](#reward-weight) are stored as val
 
 - For Tax Rate, in order to make sure that unit mining rewards do not stay stagnant, the treasury adds a [`MiningIncrement`](#miningincrement) so mining rewards increase steadily over time, described [here](#kupdatetaxpolicy).
 
-- For Reward Weight, The Treasury observes the portion of burden seigniorage needed to bear the overall reward profile, [`SeigniorageBurdenTarget`](#seigniorageburdentarget), and hikes up rates accordingly, described [here](#k-updaterewardpolicy). The current Reward Weight is 100%.
+- For Reward Weight, the Treasury observes the portion of seigniorage needed to bear the overall reward profile, [`SeigniorageBurdenTarget`](#seigniorageburdentarget), and raises rates accordingly, as described [here](#k-updaterewardpolicy). The current Reward Weight is 100%.
 
 ### Probation
 
-A probationary period specified by the [`WindowProbation`](#windowprobation) will prevent the network from performing Tax Rate and Reward Weight updates during the first epochs after genesis to allow the blockchain to first obtain a critical mass of transactions and a mature and reliable history of indicators.
+A probationary period specified by the [`WindowProbation`](#windowprobation) prevents the network from performing Tax Rate and Reward Weight updates during the first epochs after genesis to allow the blockchain to first obtain a critical mass of transactions and a mature, reliable history of indicators.
 
 ## Data
 
 ### PolicyConstraints
 
-Policy updates from both governance proposals and automatic calibration are constrained by the [`TaxPolicy`](#taxpolicy) and [`RewardPolicy`](#rewardpolicy) parameters, respectively. `PolicyConstraints` specifies the floor, ceiling, and the max periodic changes for each variable.
+Policy updates from governance proposals and automatic calibration are constrained by the [`TaxPolicy`](#taxpolicy) and [`RewardPolicy`](#rewardpolicy) parameters, respectively. `PolicyConstraints` specifies the floor, ceiling, and max periodic changes for each variable.
 
 ```go
 // PolicyConstraints defines constraints around updating a key Treasury variable
@@ -68,7 +68,7 @@ type PolicyConstraints struct {
 }
 ```
 
-The logic for constraining a policy lever update is performed by `pc.Clamp()`, shown below.
+The logic for constraining a policy lever update is performed by `pc.Clamp()`.
 
 ```go
 // Clamp constrains a policy variable update within the policy constraints
@@ -107,31 +107,6 @@ type TaxRateUpdateProposal struct {
 }
 ```
 
-::: details Events
-
-| Type            | Attribute Key | Attribute Value |
-| --------------- | ------------- | --------------- |
-| tax_rate_update | tax_rate      | {taxRate}       |
-
-:::
-
-### RewardWeightUpdateProposal
-
-```go
-type RewardWeightUpdateProposal struct {
-	Title        string  `json:"title" yaml:"title"`                 // Title of the Proposal
-	Description  string  `json:"description" yaml:"description"`     // Description of the Proposal
-	RewardWeight sdk.Dec `json:"reward_weight" yaml:"reward_weight"` // target RewardWeight
-}
-```
-::: details Events
-
-| Type                 | Attribute Key | Attribute Value |
-| -------------------- | ------------- | --------------- |
-| reward_weight_update | reward_weight | {rewardWeight}  |
-
-:::
-
 ::: warning Note:
 As of Columbus-5, all seigniorage is burned. The Reward Weight is now set to 100%.
 :::
@@ -141,8 +116,8 @@ As of Columbus-5, all seigniorage is burned. The Reward Weight is now set to 100
 ### Tax Rate
 
 - type: `Dec`
-- Current min: .1%
-- Current max: 1%
+- current min: .1%
+- current max: 1%
 
 The value of the Tax Rate policy lever for the current epoch.
 
@@ -151,7 +126,7 @@ The value of the Tax Rate policy lever for the current epoch.
 - type: `Dec`
 - current: 100%
 
-The value of the Reward Weight policy lever for the current epoch. As of Columbus-5, the reward weight is set to `1`.
+The value of the Reward Weight policy lever for the current epoch. As of Columbus-5, the reward weight is set to 100%.
 
 ### Tax Caps
 
@@ -159,7 +134,7 @@ The value of the Reward Weight policy lever for the current epoch. As of Columbu
 
 The Treasury keeps a `KVStore` that maps a denomination `denom` to an `sdk.Int` which represents the maximum income that can be generated from taxes on a transaction in that same denomination. This is updated every epoch with the equivalent value of [`TaxPolicy.Cap`](#taxpolicy) at the current exchange rate.
 
-For instance, if a transaction's value were 100 SDT, and tax rate and tax cap 5% and 1 SDT respectively, the income generated from the transaction would be 1 SDT instead of 5 SDT, as it exceeds the tax cap.
+For example, if a transaction's value were 100 SDT with a tax rate of 5% and a tax cap of 1 SDT, the income generated would be 1 SDT, not 5 SDT.
 
 ### Tax Proceeds
 
@@ -171,9 +146,9 @@ The Tax Rewards $T$ for the current epoch.
 
 - type: `Coins`
 
-The total supply of Luna at the beginning of the current epoch. This value is used in [`k.SettleSeigniorage()`](#k-settleseigniorage) to calculate the seigniorage to distribute at the end of the epoch.
+The total supply of Luna at the beginning of the current epoch. This value is used in [`k.SettleSeigniorage()`](#k-settleseigniorage) to calculate the seigniorage distributed at the end of each epoch. As of Columbus 5, all seigniorage is burned.
 
-Recording the initial issuance will automatically use the [`Supply`](spec-supply.md) module to determine the total issuance of Luna. Peeking will return the epoch's initial issuance of µLuna as `sdk.Int` instead of `sdk.Coins` for convenience.
+Recording the initial issuance will automatically use the [`Supply`](spec-supply.md) module to determine the total issuance of Luna. Peeking will return the epoch's initial issuance of µLuna as `sdk.Int` instead of `sdk.Coins` for clarity.
 
 ### Indicators
 
@@ -183,19 +158,19 @@ The Treasury keeps track of following indicators for the present and previous ep
 
 - type: `Dec`
 
-The Tax Rewards $T$ for the `epoch`.
+The Tax Rewards $T$ for each `epoch`.
 
 #### Seigniorage Rewards
 
 - type: `Dec`
 
-The Seigniorage Rewards $S$ for the `epoch`.
+The Seigniorage Rewards $S$ for each `epoch`.
 
 #### Total Staked Luna
 
 - type: `Int`
 
-The Total Staked Luna $\lambda$ for the `epoch`.
+The Total Staked Luna $\lambda$ for each `epoch`.
 
 ## Functions
 
@@ -205,11 +180,11 @@ The Total Staked Luna $\lambda$ for the `epoch`.
 func (k Keeper) UpdateIndicators(ctx sdk.Context)
 ```
 
-This function gets run at the end of an epoch $t$ and records the current values of tax rewards $T$, seigniorage rewards $S$, and total staked Luna $\lambda$ as the historic indicators for epoch $t$ before moving to the next epoch $t+1$.
+At the end of each epoch $t$, this function records the current values of tax rewards $T$, seigniorage rewards $S$, and total staked Luna $\lambda$ before moving to the next epoch $t+1$.
 
 - $T_t$ is the current value in [`TaxProceeds`](#tax-proceeds)
 - $S_t = \Sigma * w$, with epoch seigniorage $\Sigma$ and reward weight $w$.
-- $\lambda_t$ is simply the result of `staking.TotalBondedTokens()`
+- $\lambda_t$ is the result of `staking.TotalBondedTokens()`
 
 ### `k.UpdateTaxPolicy()`
 
@@ -217,19 +192,19 @@ This function gets run at the end of an epoch $t$ and records the current values
 func (k Keeper) UpdateTaxPolicy(ctx sdk.Context) (newTaxRate sdk.Dec)
 ```
 
-This function gets called at the end of an epoch to calculate the next value of the Tax Rate monetary lever.
+At the end of each epoch, this funtion calculates the next value of the Tax Rate monetary lever.
 
-Consider $r_t$ to be the current Tax Rate, and $n$ to be the [`MiningIncrement`](#miningincrement) parameter.
+Using $r_t$ as the current Tax Rate and $n$ as the [`MiningIncrement`](#miningincrement) parameter:
 
 1. Calculate the rolling average $\tau_y$ of Tax Rewards per unit Luna over the last year `WindowLong`.
 
 2. Calculate the rolling average $\tau_m$ of Tax Rewards per unit Luna over the last month `WindowShort`.
 
-3. If $\tau_m = 0$, there was no tax revenue in the last month. The Tax Rate should thus be set to the maximum permitted by the Tax Policy, subject to the rules of `pc.Clamp()` (see [constraints](#policy-constraints)).
+3. If $\tau_m = 0$, there was no tax revenue in the last month. The Tax Rate should be set to the maximum permitted by the Tax Policy, subject to the rules of `pc.Clamp()` (see [constraints](#policy-constraints)).
 
-4. Otherwise, the new Tax Rate is $r_{t+1} = (n r_t \tau_y)/\tau_m$, subject to the rules of `pc.Clamp()` (see [constraints](#policy-constraints)).
+4. If $\tau_m > 0$, the new Tax Rate is $r_{t+1} = (n r_t \tau_y)/\tau_m$, subject to the rules of `pc.Clamp()`. See [constraints](#policy-constraints) for more details.
 
-As such, the Treasury hikes up Tax Rate when tax revenues in a shorter time window are performing poorly in comparison to the longer term tax revenue average. It lowers Tax Rate when short term tax revenues are outperforming the longer term index.
+When monthly tax revenues dip below the yearly average, the Treasury raises the Tax Rate. When monthly tax revenues go above the yearly average, the Treasury lowers the Tax Rate.
 
 ### `k.UpdateRewardPolicy()`
 
@@ -237,20 +212,21 @@ As such, the Treasury hikes up Tax Rate when tax revenues in a shorter time wind
 func (k Keeper) UpdateRewardPolicy(ctx sdk.Context) (newRewardWeight sdk.Dec)
 ```
 
-This function gets called at the end of an epoch to calculate the next value of the Reward Weight monetary lever.
+At the end of each epoch, this funtion calculates the next value of the Reward Weight monetary lever.
 
-Consider $w_t$ to be the current reward weight, and $b$ to be the [`SeigniorageBurdenTarget`](#seigniorageburdentarget) parameter.
+Using $w_t$ as the current reward weight, and $b$ as the [`SeigniorageBurdenTarget`](#seigniorageburdentarget) parameter:
 
-1. Calculate the sum of $S_m$ of seigniorage rewards over the last month `WindowShort`.
+1. Calculate the sum $S_m$ of seigniorage rewards over the last month `WindowShort`.
 
-2. Calculate the sum of $R_m$ of total mining rewards over the last month `WindowShort`.
+2. Calculate the sum $R_m$ of total mining rewards over the last month `WindowShort`.
 
-3. If either $R_m = 0$ or $S_m = 0$ there was no mining and seigniorage rewards in the last month. The Rewards Weight should thus be set to the maximum permitted by the Reward Policy, subject to the rules of `pc.Clamp()` (see [constraints](#policy-constraints)).
+3. If $R_m = 0$ and $S_m = 0$, there were no mining or seigniorage rewards in the last month. The Reward Weight should be set to the maximum permitted by the Reward Policy, subject to the rules of `pc.Clamp()`. See [constraints](#policy-constraints) for more details.
 
-4. Otherwise, the new Reward Weight is $w_{t+1} = b w_t S_m / R_m$, subject to the rules of `pc.Clamp()` (see [constraints](#policy-constraints)).
+4. If $R_m > 0$ or $S_m > 0$, the new Reward Weight is $w_{t+1} = b w_t S_m / R_m$, subject to the rules of `pc.Clamp()`. See [constraints](#policy-constraints) for more details.
+
 
 ::: warning Note:
-As of Columbus-5, all seigniorage is burned. The current reward weight is `1`.
+As of Columbus-5, all seigniorage is burned and no longer funds the community or reward pools.
 :::
 
 ### `k.UpdateTaxCap()`
@@ -261,7 +237,7 @@ func (k Keeper) UpdateTaxCap(ctx sdk.Context) sdk.Coins
 
 This function is called at the end of an epoch to compute the Tax Caps for every denomination for the next epoch.
 
-For each denomination in circulation, the new Tax Cap for that denomination is set to be the global Tax Cap defined in the [`TaxPolicy`](#taxpolicy) parameter, at current exchange rates.
+For every denomination in circulation, the new Tax Cap for each denomination is set to be the global Tax Cap defined in the [`TaxPolicy`](#taxpolicy) parameter, at current exchange rates.
 
 ### `k.SettleSeigniorage()`
 

--- a/docs/terrad/treasury.md
+++ b/docs/terrad/treasury.md
@@ -58,7 +58,7 @@ Parameters define the high-level settings for the Treasury, described [here](../
 terrad query treasury params
 ```
 
-The reported parameters will be in the following format:
+The reported parameters are in the following format:
 
 ```yaml
 tax_policy:

--- a/docs/terrad/treasury.md
+++ b/docs/terrad/treasury.md
@@ -12,7 +12,7 @@ terrad query treasury tax-rate
 
 ### Tax Cap
 
-Stability fees are capped at some fixed amount of SDT to avoid penalizing large transactions. To get the current tax cap denominated in a given denomination (micro-units), run:
+Stability fees are capped at a fixed amount of SDT to avoid penalizing large transactions. To get the current tax cap denominated in a given denomination (micro-units), run:
 
 ```bash
 terrad query treasury tax-cap <denom>
@@ -34,6 +34,10 @@ The Reward Weight is the portion of seigniorage that is designated as ballot rew
 terrad query treasury reward-weight
 ```
 
+::: warning Note:
+As of Columbus-5, the `reward-weight` is set to `1`.
+:::
+
 ### Seigniorage Proceeds
 
 The treasury measures the amount of Terra seigniorage accumulated over epochs, denominated in units of `uluna`. To query the seigniorage proceeds, run:
@@ -42,15 +46,19 @@ The treasury measures the amount of Terra seigniorage accumulated over epochs, d
 terrad query treasury seigniorage-proceeds
 ```
 
+::: warning Note:
+As of Columbus-5, all seigniorage is burned.
+:::
+
 ### Parameters
 
-Parameters define high-level settings for the Treasury, described [here](../dev/spec-treasury.md#parameters). You can get the current values by using:
+Parameters define the high-level settings for the Treasury, described [here](../dev/spec-treasury.md#parameters). You can get the current values by using:
 
 ```bash
 terrad query treasury params
 ```
 
-The reported parameters will be of the following format:
+The reported parameters will be in the following format:
 
 ```yaml
 tax_policy:


### PR DESCRIPTION
I have edited terrad/treasury and dev/spec-treasury to reflect changes to seigniorage. I have kept existing descriptions of seigniorage logic, and added notes that specify that all seigniorage is burned in Columbus-5. I have also updated the reward weight to 1. 