### PR TITLE
fix: Fix python sdk links.

### DIFF
--- a/docs/.vuepress/theme/components/Sidebar.vue
+++ b/docs/.vuepress/theme/components/Sidebar.vue
@@ -18,7 +18,7 @@
           </div>
         </div>
       </a>-->
-      <a href="https://terra-money.github.io/terra-sdk-python/" target="_blank">
+      <a href="https://terra-money.github.io/terra.py/" target="_blank">
         <div class="image">
           <img src="https://www.terra.money/assets/img/terra_sdk.svg" />
         </div>

--- a/docs/Concepts/README.md
+++ b/docs/Concepts/README.md
@@ -83,7 +83,7 @@ Learn more about Terra, stablecoins, and how the protocol works by exploring the
 The Terra SDKs provide an easy way to programmatically interact with a Terra node with popular programming languages to develop applications. Currently, we have SDKs in Python 3 and JavaScript, with support for other runtimes coming soon in the near future.
 
 <div class="cards twoColumn">
-  <a href="https://terra-money.github.io/terra-sdk-python/" class="card lg dark">
+  <a href="https://terra-money.github.io/terra.py/" class="card lg dark">
     <img src="https://terra.money/assets/img/terra_sdk.svg">
     <div class="title">
       Terra SDK

--- a/docs/Concepts/Smart-contracts.md
+++ b/docs/Concepts/Smart-contracts.md
@@ -10,7 +10,7 @@ The following table maps commonly-used Ethereum developer tools to their Terra c
 
 |                    | Terra                                                                                                                 | Ethereum        |
 | ------------------ | --------------------------------------------------------------------------------------------------------------------- | --------------- |
-| Frontend SDK       | [Terra.js](https://terra-money.github.io/terra.js/), [Terra SDK](https://terra-money.github.io/terra-sdk-python/) | Web3.js, Web3py |
+| Frontend SDK       | [Terra.js](https://terra-money.github.io/terra.js/), [Terra SDK](https://terra-money.github.io/terra.py/) | Web3.js, Web3py |
 | Browser Extension  | Station CX                                                                                                            | MetaMask, MEW   |
 | Local Testnet      | [LocalTerra](https://github.com/terra-money/LocalTerra)                                                             | Ganache         |
 | Contract Language  | [Rust](https://www.rust-lang.org/)                                                                                    | Solidity, Vyper |

--- a/docs/How-to/Manage-funds-Terra-Station/README.md
+++ b/docs/How-to/Manage-funds-Terra-Station/README.md
@@ -82,7 +82,7 @@ Rewrite and update links
 The Terra SDKs provide an easy way to programmatically interact with a Terra node with popular programming languages to develop applications. Currently, we have SDKs in Python 3 and JavaScript, with support for other runtimes coming soon in the near future.
 
 <div class="cards twoColumn">
-  <a href="https://terra-money.github.io/terra-sdk-python/" class="card lg dark">
+  <a href="https://terra-money.github.io/terra.py/" class="card lg dark">
     <img src="https://terra.money/assets/img/terra_sdk.svg">
     <div class="title">
       Terra SDK

--- a/docs/How-to/README.md
+++ b/docs/How-to/README.md
@@ -83,7 +83,7 @@ Learn how to run a full Terra node and manage a validator by using the informati
 The Terra SDKs provide an easy way to programmatically interact with a Terra node with popular programming languages to develop applications. Currently, we have SDKs in Python 3 and JavaScript, with support for other runtimes coming soon in the near future.
 
 <div class="cards twoColumn">
-  <a href="https://terra-money.github.io/terra-sdk-python/" class="card lg dark">
+  <a href="https://terra-money.github.io/terra.py/" class="card lg dark">
     <img src="https://terra.money/assets/img/terra_sdk.svg">
     <div class="title">
       Terra SDK

--- a/docs/README.md
+++ b/docs/README.md
@@ -82,7 +82,7 @@ Welcome to the official documentation for Terra, a decentralized financial infra
 The Terra SDKs provide an easy way to programmatically interact with a Terra node with popular programming languages to develop applications. Currently, we have SDKs in Python 3 and JavaScript, with support for other runtimes coming soon in the near future.
 
 <div class="cards twoColumn">
-  <a href="https://terra-money.github.io/terra-sdk-python/" class="card lg dark">
+  <a href="https://terra-money.github.io/terra.py/" class="card lg dark">
     <img src="https://www.terra.money/assets/img/terra_sdk.svg">
     <div class="title">
       Terra SDK

--- a/docs/Reference/README.md
+++ b/docs/Reference/README.md
@@ -83,7 +83,7 @@ Use this section to quickly find the information you need about the Terra core m
 The Terra SDKs provide an easy way to programmatically interact with a Terra node with popular programming languages to develop applications. Currently, we have SDKs in Python 3 and JavaScript, with support for other runtimes coming soon in the near future.
 
 <div class="cards twoColumn">
-  <a href="https://terra-money.github.io/terra-sdk-python/" class="card lg dark">
+  <a href="https://terra-money.github.io/terra.py/" class="card lg dark">
     <img src="https://terra.money/assets/img/terra_sdk.svg">
     <div class="title">
       Terra SDK

--- a/docs/Tutorials/README.md
+++ b/docs/Tutorials/README.md
@@ -83,7 +83,7 @@ Learn how to [use Terra Station to manage your funds](./Get-started/Use-Terra-St
 The Terra SDKs provide an easy way to programmatically interact with a Terra node with popular programming languages to develop applications. Currently, we have SDKs in Python 3 and JavaScript, with support for other runtimes coming soon in the near future.
 
 <div class="cards twoColumn">
-  <a href="https://terra-money.github.io/terra-sdk-python/" class="card lg dark">
+  <a href="https://terra-money.github.io/terra.py/" class="card lg dark">
     <img src="https://terra.money/assets/img/terra_sdk.svg">
     <div class="title">
       Terra SDK

--- a/docs/Tutorials/Smart-contracts/Overview.md
+++ b/docs/Tutorials/Smart-contracts/Overview.md
@@ -10,7 +10,7 @@ The following table maps commonly-used Ethereum developer tools to their Terra c
 
 |                    | Terra                                                                                                                 | Ethereum        |
 | ------------------ | --------------------------------------------------------------------------------------------------------------------- | --------------- |
-| Frontend SDK       | [Terra.js](https://terra-money.github.io/terra.js/), [Terra SDK](https://terra-money.github.io/terra-sdk-python/) | Web3.js, Web3py |
+| Frontend SDK       | [Terra.js](https://terra-money.github.io/terra.js/), [Terra SDK](https://terra-money.github.io/terra.py/) | Web3.js, Web3py |
 | Browser Extension  | Station CX                                                                                                            | MetaMask, MEW   |
 | Local Testnet      | [LocalTerra](https://github.com/terra-money/LocalTerra)                                                             | Ganache         |
 | Contract Language  | [Rust](https://www.rust-lang.org/)                                                                                    | Solidity, Vyper |


### PR DESCRIPTION
https://terra-money.github.io/terra-sdk-python/ is no more, so I used sed to update all links. 

Here's the new home: https://terra-money.github.io/terra.py/