### PR TITLE
[Enhancement] refer to v0.x.x* refs as tags instead of branches

### DIFF
--- a/docs/How-to/Run-a-full-Terra-node/Build-Terra-core.md
+++ b/docs/How-to/Run-a-full-Terra-node/Build-Terra-core.md
@@ -9,7 +9,7 @@
 
 Use `git` to retrieve [Terra core](https://github.com/terra-money/core/), and checkout the `master` branch, which contains the latest stable release.
 
-If you are using LocalTerra or running a validator, use the `v0.x.x-oracle` branch. Otherwise, use the `v0.x.x` branch.
+If you are using LocalTerra or running a validator, use the `v0.x.x-oracle` tag. Otherwise, use the `v0.x.x` tag.
 
 ```bash
 git clone https://github.com/terra-money/core


### PR DESCRIPTION
v0.x.x-oracle and v0.x.x are tags in the terra core repository so I updated their types in the docs. 
Noticed some confusion on the Terrabites Developer Deep Dive Vol. 001 video so thought I'd add the fix. 