### PR TITLE
Add terrad readme to nav

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -218,6 +218,7 @@ module.exports = {
           title: "terrad",
           collapsable: true,
           children: [
+            "/Reference/terrad/",
             "/Reference/terrad/commands",
             "/Reference/terrad/subcommands",
         ],

--- a/docs/Reference/Terra-core/Module-specifications/spec-auth.md
+++ b/docs/Reference/Terra-core/Module-specifications/spec-auth.md
@@ -12,7 +12,7 @@ The Auth module reads the current effective `TaxRate` and `TaxCap` parameters fr
 
 ### Gas Fee
 
-As with any other transaction, [`MsgSend`](./spec-bank.md#msgsend) and [`MsgMultiSend`](./spec-bank.md#msgmultisend) pay a gas fee the size of which depends on validator's preferences (each validator sets his own min-gas-fees) and the complexity of the transaction. [Notes on gas and fees](../terrad/README.md#a-note-on-gas-and-fees) has a more detailed explanation of how gas is computed. Important detail to note here is that gas fees are specified by the sender when the transaction is outbound.
+As with any other transaction, [`MsgSend`](./spec-bank.md#msgsend) and [`MsgMultiSend`](./spec-bank.md#msgmultisend) pay a gas fee the size of which depends on validator's preferences (each validator sets his own min-gas-fees) and the complexity of the transaction. [Notes on gas and fees](/Reference/terrad/#fees) has a more detailed explanation of how gas is computed. Important detail to note here is that gas fees are specified by the sender when the transaction is outbound.
 
 ### Stability Fee
 

--- a/docs/Reference/terrad/README.md
+++ b/docs/Reference/terrad/README.md
@@ -1,4 +1,4 @@
-# terrad
+# Using terrad
 
 The following information explains the functions you can use from `terrad`, the command line interface that connects a running `terrad` process. Use it to access Terra. For more general information at the command line, run `terrad --help`. For more information about a specific `terrad` command, append the `-h` or `--help` flag after the command, such as `terrad query --help`.
 


### PR DESCRIPTION
I have added the terrad readme to the nav. 

@stevenTerra I named the page "Using terrad" over "terrad overview" to maintain our title-capitalization style. 

@octalmage can you glance through this to make sure commands are still valid?