### PR TITLE
docs: Recommend Wallet Provider.

### DIFF
--- a/docs/SDKs/Terra-js/Station-extension.md
+++ b/docs/SDKs/Terra-js/Station-extension.md
@@ -8,9 +8,9 @@ The Terra Station extension is a web-wallet extension for Chrome that enables we
 
 ## Wallet Provider
 
-Wallet Provider is a library to make React dApps easier using Terra Station Extension or Terra Station Mobile.
+Wallet Provider is a library that simplifies the development of React dApps that use Terra Station extension or Terra Station mobile.
 
-Use one of the following templates for a head start with Wallet Provider: 
+Use one of the following templates to get quickly get started using Wallet Provider: 
 
 ### Create React App
 
@@ -34,12 +34,14 @@ yarn run dev
 
 [Learn more](https://github.com/terra-money/wallet-provider/tree/main/templates/next)
 
-### Other templates (experimental)
+### Experimental templates
 
 - [Wallet Provider + Vite.js](https://github.com/terra-money/wallet-provider/tree/main/templates/vite)
 - [Wallet Controller](https://github.com/terra-money/wallet-provider/tree/main/templates/wallet-controller)
 
-The Wallet Controller template is an example of how WalletController behaves underneath the React API. This would be a good place to start if you are unable to use React.
+::: tip
+The Wallet Controller template is an example of how WalletController behaves underneath the React API. If you are unable to use React, start by using the Wallet Controller template.
+:::
 
 ## Usage 
 

--- a/docs/SDKs/Terra-js/Station-extension.md
+++ b/docs/SDKs/Terra-js/Station-extension.md
@@ -6,25 +6,43 @@ The API for the Terra Station extension is undergoing rapid development and is h
 
 The Terra Station extension is a web-wallet extension for Chrome that enables webpages to create requests for signing and broadcasting transactions. The webpage can detect the presence of Station Extension and generate a prompt whereby the user can confirm the transaction to be signed.
 
-## Connect
+## Wallet Provider
 
-```ts
-import { Extension, Wallet } from "@terra-money/@terra.js";
+Wallet Provider is a library to make React dApps easier using Terra Station Extension or Terra Station Mobile.
 
-let wallet: Wallet;
-const extension = new Extension();
-extension.connect();
-extension.on("connect", (w: Wallet) => {
-  w = wallet;
-});
+Use one of the following templates for a head start with Wallet Provider: 
+
+### Create React App
+
+```sh
+npx copy-github-directory https://github.com/terra-money/wallet-provider/tree/main/templates/create-react-app your-app-name
+cd your-app-name
+yarn install
+yarn start
 ```
 
-## Sign a message
+[Learn more](https://github.com/terra-money/wallet-provider/tree/main/templates/create-react-app)
 
-```ts
-import { MsgSend } from "@terra-money/terra.js";
+### Next.js
 
-extension.post({
-  msgs: []
-});
+```sh
+npx copy-github-directory https://github.com/terra-money/wallet-provider/tree/main/templates/next your-app-name
+cd your-app-name
+yarn install
+yarn run dev
 ```
+
+[Learn more](https://github.com/terra-money/wallet-provider/tree/main/templates/next)
+
+### Other templates (experimental)
+
+- [Wallet Provider + Vite.js](https://github.com/terra-money/wallet-provider/tree/main/templates/vite)
+- [Wallet Controller](https://github.com/terra-money/wallet-provider/tree/main/templates/wallet-controller)
+
+The Wallet Controller template is an example of how WalletController behaves underneath the React API. This would be a good place to start if you are unable to use React.
+
+## Usage 
+
+Visit the Wallet Provider GitHub for more details on using the APIs provided: 
+
+[https://github.com/terra-money/wallet-provider](https://github.com/terra-money/wallet-provider#basic-usage)


### PR DESCRIPTION
Instead of using Terra.js directly to talk to Terra Station, it's recommended to use the much more user friendly Wallet Provider package. 

I took a quick stab at getting the outdated info removed, and pointing people to the correct place.

![localhost_8080_SDKs_Terra-js_Station-extension html](https://user-images.githubusercontent.com/142006/145120828-9125e450-119d-4e7f-b7d7-0cfff317c2ac.png)

I do think we should provide more real life examples on this page, this is something that's currently missing from the GitHub.