### PR TITLE
Include smart contract note about WSL 1

### DIFF
--- a/docs/Tutorials/Smart-contracts/Write-smart-contract.md
+++ b/docs/Tutorials/Smart-contracts/Write-smart-contract.md
@@ -325,7 +325,7 @@ Please note that rust-optimizer will produce different contracts on Intel and AR
 :::
 
 ::: warning NOTE
-If you are developing with a Windows exposed Docker daemon connected to WSL 1, you will need to replace the `pwd` and `basename "$(pwd)"` steps of the optimization command with the absolute path of your smart contract folder, or Docker will be unable to optimize your build.
+If you are developing with a Windows exposed Docker daemon connected to WSL 1, you will need to replace the `pwd` and `basename "$(pwd)"` steps of the optimization command with the windows absolute path of your smart contract folder, or Docker will be unable to optimize your build.
 :::
 
 

--- a/docs/Tutorials/Smart-contracts/Write-smart-contract.md
+++ b/docs/Tutorials/Smart-contracts/Write-smart-contract.md
@@ -332,6 +332,7 @@ This will result in an optimized build of `artifacts/my_first_contract.wasm` or 
 Please note that rust-optimizer will produce different contracts on Intel and ARM machines. So for reproducible builds you'll have to stick to one.
 :::
 
+
 ## Schemas
 
 In order to make use of JSON-schema auto-generation, we should register each of the data structures that we need schemas for.

--- a/docs/Tutorials/Smart-contracts/Write-smart-contract.md
+++ b/docs/Tutorials/Smart-contracts/Write-smart-contract.md
@@ -324,6 +324,10 @@ This will result in an optimized build of `artifacts/my_first_contract.wasm` or 
 Please note that rust-optimizer will produce different contracts on Intel and ARM machines. So for reproducible builds you'll have to stick to one.
 :::
 
+::: warning NOTE
+If you are developing with a Windows exposed Docker daemon connected to WSL 1, you will need to replace the `pwd` and `basename "$(pwd)"` steps of the optimization command with the absolute path of your smart contract folder, or Docker will be unable to optimize your build.
+:::
+
 
 ## Schemas
 

--- a/docs/Tutorials/Smart-contracts/Write-smart-contract.md
+++ b/docs/Tutorials/Smart-contracts/Write-smart-contract.md
@@ -318,16 +318,19 @@ docker run --rm -v "$(pwd)":/code \
   cosmwasm/rust-optimizer-arm64:0.12.4
   ```
 
+Or, if you are developing with a Windows exposed Docker daemon connected to WSL 1:
+```sh
+docker run --rm -v "$(wslpath -w $(pwd))":/code \
+  --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
+  --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
+  cosmwasm/rust-optimizer:0.12.4
+```
+
 This will result in an optimized build of `artifacts/my_first_contract.wasm` or `artifacts/my_first_contract-aarch64.wasm` in your working directory.
 
 ::: warning NOTE
 Please note that rust-optimizer will produce different contracts on Intel and ARM machines. So for reproducible builds you'll have to stick to one.
 :::
-
-::: warning NOTE
-If you are developing with a Windows exposed Docker daemon connected to WSL 1, you will need to replace the `pwd` and `basename "$(pwd)"` steps of the optimization command with the windows absolute path of your smart contract folder, or Docker will be unable to optimize your build.
-:::
-
 
 ## Schemas
 


### PR DESCRIPTION
If you are using Docker Desktop on Windows and exposing the daemon without TLS, and then connect to it through WSL (see https://pscheit.medium.com/use-docker-for-windows-in-wsl-8fc96ece67c8), then any commands that use UNIX filesystem (such as `pwd`) will resolve to an invalid Windows path. It is therefore necessary to manually insert the file paths, or Docker will fail with the error `error: could not find Cargo.toml in /code or any parent directory`.

This pull request aims to clarify this behavior for anyone who may use WSL 1 paired with Docker Desktop on Windows.