### PR TITLE
go version limits

### DIFF
--- a/docs/How-to/Run-a-full-Terra-node/Build-Terra-core.md
+++ b/docs/How-to/Run-a-full-Terra-node/Build-Terra-core.md
@@ -4,7 +4,7 @@ Terra core is the official Golang reference implementation of the Terra node sof
 
 ## Prerequisites
 
-- [Golang v1.16.1 or higher](https://golang.org/doc/install)
+- [Any Golang Version between v1.16.1 and go1.17.1 linux/amd64](https://golang.org/doc/install)
 - Ensure your `GOPATH` and `GOBIN` environment variables are set up correctly.
 
 ## Get the Terra core source code

--- a/docs/How-to/Run-a-full-Terra-node/Build-Terra-core.md
+++ b/docs/How-to/Run-a-full-Terra-node/Build-Terra-core.md
@@ -4,7 +4,7 @@ Terra core is the official Golang reference implementation of the Terra node sof
 
 ## Prerequisites
 
-- [Any Golang Version between v1.16.1 and go1.17.1 linux/amd64](https://golang.org/doc/install)
+- [Golang v1.16.1 - go1.17.1 linux/amd64](https://golang.org/doc/install)
 - Ensure your `GOPATH` and `GOBIN` environment variables are set up correctly.
 
 ## Get the Terra core source code


### PR DESCRIPTION
It was found that go version go version go1.17.5 linux/amd64 is not compatible with terra core.
version: go1.17.1 linux/amd64 was found to work properly.

This edit adds the upper limit for current go version.