### PR TITLE
Update instructions for sentry nodes

### DIFF
--- a/docs/How-to/Manage-a-Terra-validator/Implement-security.md
+++ b/docs/How-to/Manage-a-Terra-validator/Implement-security.md
@@ -25,7 +25,7 @@ Learn more about [sentry-node architecture](https://forum.cosmos.network/t/sentr
 ```bash
 # Comma separated list of nodes to keep persistent connections to
 # Do not add private peers to this list if you don't want them advertised
-persistent_peers =[list of sentry nodes]
+persistent_peers = "comma separated list of sentry node addresses"
 
 # Set true to enable the peer-exchange reactor
 pex = false
@@ -34,9 +34,15 @@ pex = false
 2. For sentry nodes, edit the `config.toml`:
 
 ```bash
+# Comma separated list of nodes to keep persistent connections to
+# Do not add private peers to this list if you don't want them advertised
+persistent_peers = "validator node address"
+
 # Comma separated list of peer IDs to keep private (will not be gossiped to other peers)
-private_peer_ids = "ipaddress of validator nodes"
+private_peer_ids = "nodeid of the validator"
 ```
+
+::: warning Note a node address has this format: `nodeid@ip:port`, you can get the nodeid by running `terrad tendermint show-node-id`, the default port is 26656. :::
 
 ## Environment Variables
 


### PR DESCRIPTION
Updated instructions for sentry nodes, summary of the changes:
 - **persistent_peers** must be passed as a comma separated string, not as an array
 - the validator should also add sentry nodes as persistent peers
 - **private_peer_ids** must contain the nodeid of the validator, not it's ip address
 - added information on how to generate the node address