### PR TITLE
Redirect old station link

### DIFF
--- a/docs/learn/terra-station/download/terra-station-extension.md
+++ b/docs/learn/terra-station/download/terra-station-extension.md
@@ -31,7 +31,6 @@ Complete this tutorial to install the Terra Station extension for the Google Chr
 
 ## Prerequisites
 
-- Download and install [Terra Station for desktop](terra-station-desktop.md).
 - Download [Google Chrome](https://www.google.com/chrome/).
 
 ## Install the Terra Station extension

--- a/redirects/Tutorials/Get-started/Use-Terra-Station.html
+++ b/redirects/Tutorials/Get-started/Use-Terra-Station.html
@@ -1,0 +1,9 @@
+<html>
+  <head>
+    <meta http-equiv="refresh" content="0; url=http://docs.terra.money/docs/learn/terra-station/README.html" />
+  </head>
+
+  <body>
+    <p><a href="http://docs.terra.money/docs/learn/terra-station/README.html">Redirect</a></p>
+  </body>
+</html>


### PR DESCRIPTION
Two fixes here:

* Redirect link on https://faucet.terra.money/ to the new link. 
* Terra station desktop is not required for the Chrome extension.