### PR TITLE
Fix spacing for Epoch headline

### DIFF
--- a/docs/learn/glossary.md
+++ b/docs/learn/glossary.md
@@ -89,7 +89,7 @@ When users or delegators add their [Luna](#luna) to a [validator's](#validator) 
 
 A user who [delegates](#delegate), bonds, or stakes [Luna](#luna) to a [validator](#validator) to earn [rewards](#rewards). Delegating, bonding, and staking generally refer to the same process.
 
-##Epoch
+## Epoch
 
 A length of time measured in [blocks](#blocks). An epoch for the governance module occurs every 100800 blocks, or roughly every 7.7 days, given a 6.6-second block time. Block times may vary.
 


### PR DESCRIPTION
Hi, just found a small typo as I was reading thru the docs and decided to help fix it.