### PR TITLE
Node JS versin

### DIFF
--- a/docs/develop/dapp/quick-start/initial-setup.md
+++ b/docs/develop/dapp/quick-start/initial-setup.md
@@ -15,6 +15,7 @@ Terrain will help you:
 - [Docker](https://www.docker.com/)
 - [`docker-compose`](https://github.com/docker/compose)
 - [NPM](https://www.npmjs.com/)
+- [Node JS v16](https://nodejs.org/download/release/latest-v16.x/)
 
 ## 1. Set up Rust
 


### PR DESCRIPTION
terrain encounters errors if Node JS version is not v 16

https://nodejs.org/download/release/latest-v16.x/