### PR TITLE
feat: Use test1 to deploy to avoid account sequence mismatch.

### DIFF
--- a/docs/develop/dapp/quick-start/contract-migration.md
+++ b/docs/develop/dapp/quick-start/contract-migration.md
@@ -52,11 +52,11 @@ This flag tells Terra that the transaction signer is allowed to migrate the cont
 
 
    ```
-   terrain deploy counter --signer validator --set-signer-as-admin
+   terrain deploy counter --signer test1 --set-signer-as-admin
    ```
 
 With the new contract deployed you can make some changes then migrate to the new code with the following command: 
 
    ```
-   terrain contract:migrate counter --signer validator
+   terrain contract:migrate counter --signer test1
    ```

--- a/docs/develop/dapp/quick-start/using-terrain-localterra.md
+++ b/docs/develop/dapp/quick-start/using-terrain-localterra.md
@@ -90,7 +90,7 @@ The following structure shows your scaffolded project:
 To deploy the application, run the following command:
 
 ```sh
-terrain deploy counter --signer validator
+terrain deploy counter --signer test1
 ```
 
 The deploy command performs the following steps automatically:

--- a/docs/develop/dapp/quick-start/using-terrain-testnet.md
+++ b/docs/develop/dapp/quick-start/using-terrain-testnet.md
@@ -89,7 +89,7 @@ Wait a few seconds then try the deploy command again.
 
 Besides the CLI approach above, there is also the option of deploying and interacting with your contracts on testnet through the [Terra Station UI](https://station.terra.money/).
 
-1. Compile your project with `terrain`. If you have localterra running, this can be done with `terrain deploy <project> --signer validator`. This will build the wasm bytecode and output a **.wasm** file such as **artifacts/counter.wasm**
+1. Compile your project with `terrain`. If you have localterra running, this can be done with `terrain deploy <project> --signer test1`. This will build the wasm bytecode and output a **.wasm** file such as **artifacts/counter.wasm**
 
 2. You can now upload this contract to the testnet via Station. Go to [https://station.terra.money/contract](https://station.terra.money/contract) and click on "Upload"
 


### PR DESCRIPTION
We've found that when using LocalTerra using the test1 account instead of validator will eliminate all account sequence mismatch errors. 

Thanks Mike! 