### PR TITLE
docs: update go version to 1.18

### DIFF
--- a/docs/develop/how-to/terrad/install-terrad.md
+++ b/docs/develop/how-to/terrad/install-terrad.md
@@ -6,7 +6,7 @@ This guide is for developers who want to install `terrad` and interact with Terr
 
 ### Prerequisites
 
-- [Golang v1.16.1 - go1.17.1 linux/amd64](https://golang.org/doc/install)
+- [Golang v1.16.1 - go1.18 linux/amd64](https://golang.org/doc/install)
 - Ensure your `GOPATH` and `GOBIN` environment variables are set up correctly.
 - Linux users: install [build-essential](http://linux-command.org/en/build-essential.html).
 

--- a/docs/full-node/run-a-full-terra-node/system-config.md
+++ b/docs/full-node/run-a-full-terra-node/system-config.md
@@ -16,7 +16,7 @@ Running a full Terra node is a resource-intensive process that requires a persis
 
 ## Prerequisites
 
-- [Golang v1.16.1 - go1.17.1 linux/amd64](https://go.dev/dl/)
+- [Golang v1.16.1 - go1.18 linux/amd64](https://go.dev/dl/)
 
   ::: {dropdown} Installing Go for MacOS & Linux
 


### PR DESCRIPTION
Going thru the docs I have tried to install core with go v 1.18, so far I can tell that it works as expected:
![image](https://user-images.githubusercontent.com/49301655/161538490-6c2dad9f-6e20-4e85-bcf0-58659a93f65e.png)
>  image shows that new blocks are validating
