### PR TITLE
Remove fcd from docs

### DIFF
--- a/docs/develop/terra-js/common-examples.md
+++ b/docs/develop/terra-js/common-examples.md
@@ -16,7 +16,7 @@ import { MsgSend, MnemonicKey, Coins, LCDClient } from "@terra-money/terra.js";
 
 // Fetch gas prices and convert to `Coin` format.
 const gasPrices = await (
-  await fetch("https://pisco-fcd.terra.dev/v1/txs/gas_prices")
+  await fetch("https://pisco-api.terra.dev/gas-prices", { redirect: 'follow' })
 ).json();
 const gasPricesCoins = new Coins(gasPrices);
 

--- a/docs/develop/terra-js/getting-started.md
+++ b/docs/develop/terra-js/getting-started.md
@@ -66,7 +66,7 @@ Terra’s LCD or Light Client Daemon allows users to connect to the blockchain, 
    import fetch from "isomorphic-fetch";
    import { Coins, LCDClient } from "@terra-money/terra.js";
    const gasPrices = await fetch(
-     "https://pisco-fcd.terra.dev/v1/txs/gas_prices"
+     "https://pisco-api.terra.dev/gas-prices", { redirect: 'follow' }
    );
    const gasPricesJson = await gasPrices.json();
    const gasPricesCoins = new Coins(gasPricesJson);

--- a/docs/develop/terra-js/terra-classic.md
+++ b/docs/develop/terra-js/terra-classic.md
@@ -6,14 +6,16 @@ Terra.js can be configured to work with Terra Classic by passing a boolean `isCl
 
 ```ts
 const gasPrices = await(
-  await fetch("https://bombay-fcd.terra.dev/v1/txs/gas_prices")
+  await fetch("https://columbus-api.terra.dev/gas-prices", {
+    redirect: "follow",
+  })
 ).json();
 
 const gasPricesCoins = new Coins(gasPrices);
 
 const lcd = new LCDClient({
-  URL: "https://bombay-lcd.terra.dev/",
-  chainID: "bombay-12",
+  URL: "https://columbus-lcd.terra.dev/",
+  chainID: "columbus-5",
   gasPrices: gasPricesCoins,
   gasAdjustment: "1.5",
   gas: 10000000,

--- a/docs/develop/terra-py/get-started-py.md
+++ b/docs/develop/terra-py/get-started-py.md
@@ -105,7 +105,7 @@ wallet = terra.wallet(mk)
 
 All transactions on the blockchain will require some effort from computational resources in order to be processed and accepted. The computational work expended due to processing a transaction is quantified in units of `gas`.
 
-Because the amount of gas needed may not be predetermined, the signer of the transaction must send the amount of gas that they would like to use along with the transaction. Fees are calculated by multiplying the gas amount specified in the transaction by either a user-specified price or by utilizing preset prices for each unit of gas. Current rates per unit of gas may be viewed on the [gas rates FCD page](https://fcd.terra.dev/v1/txs/gas_prices).
+Because the amount of gas needed may not be predetermined, the signer of the transaction must send the amount of gas that they would like to use along with the transaction. Fees are calculated by multiplying the gas amount specified in the transaction by either a user-specified price or by utilizing preset prices for each unit of gas. Current rates per unit of gas may be viewed on the [gas rates page](https://api.terra.dev/gas-prices).
 
 Each request you will make to the blockchain will contain a message detailing your transaction along with parameters that will help estimate the gas fee. The estimated fee must be above the minimum fee required to process the request for the transaction to be accepted. If the fee is too small to fully complete the request, you may still be responsible for charges on the processing that was carried out before the transaction failed. Gas that is left unused after the transaction will not be refunded and larger estimated fee values will not translate to any benefits for the signer.
 
@@ -114,13 +114,13 @@ import requests
 import json
 
 # Request current gas rates for future fee estimation.
-gas_price_dict = requests.get("https://fcd.terra.dev/v1/txs/gas_prices").json()
+gas_price_dict = requests.get("https://api.terra.dev/gas-prices").json()
 gas_price_dict
 ```
 
 > ```
 > {
->   "uluna": "0.01133"
+>   "uluna": "0.15"
 > }
 > ```
 

--- a/docs/full-node/run-a-full-terra-node/configure-general-settings.md
+++ b/docs/full-node/run-a-full-terra-node/configure-general-settings.md
@@ -37,7 +37,7 @@ You can update your node's moniker by editing the `moniker` field in  `~/.terra/
 
 2. Modify `minimum-gas-prices` and set the minimum price of gas a validator will accept to validate a transaction and to prevent spam.
 
-- You can [query FCD](https://fcd.terra.dev/v1/txs/gas_prices) to view the current gas prices.
+- You can [query API](https://api.terra.dev/gas-prices) to view the current gas prices.
 
 **Example**:
 

--- a/docs/learn/fees.md
+++ b/docs/learn/fees.md
@@ -13,6 +13,6 @@ Gas on Terra works differently than it works on other blockchains:
 
 For an in-depth explanation of how gas fees are calculated, visit the [terrad reference](../develop/terrad/using-terrad.md#fees) page.
 
-To view current gas rates in your browser, visit the [gas rates](https://fcd.terra.dev/v1/txs/gas_prices) FCD page.
+To view current gas rates in your browser, visit the [gas rates](https://api.terra.dev/gas-prices) page.
 
 Every block, gas fees are sent to the reward pool and dispersed to validators who distribute them to delegators in the form of staking rewards.


### PR DESCRIPTION
## Description
There are many examples which are using fcd variable for it. This PR replaces it to 'http://api.terra.dev/gas_prices'