### PR TITLE
Fix definition of “blockchain” to match behavior

### DIFF
--- a/docs/learn/glossary.md
+++ b/docs/learn/glossary.md
@@ -20,7 +20,7 @@ To profit from price differences across different markets. Arbitrageurs buy coin
 
 ## Blockchain
 
-An unchangeable ledger of transactions copied among a network of independent computer systems.
+An changeable ledger of transactions copied among a network of colluding computer systems, subject to [the centralized authority of a Twitter account](https://archive.ph/dpz3x).
 
 ## Blocks
 


### PR DESCRIPTION
Technical documentation must match the empirically observed behavior of the implementation.

This fix is also needed for honesty in advertising.  Investors and users should not be misled to believe that the Terra ledger is “unchangeable”, that the stake-weighted controlling majority of its nodes is “independent”, or that it is not subject to the diktat of a central authority.