### PR TITLE
update mainnet lcd to phoenix-lcd

### DIFF
--- a/docs/develop/terra-js/fees.md
+++ b/docs/develop/terra-js/fees.md
@@ -21,7 +21,7 @@ You can define the fee estimation parameters when you create your `LCDClient` in
 
 ```ts
 const terra = new LCDClient({
-  URL: "https://lcd.terra.dev",
+  URL: "https://phoenix-lcd.terra.dev",
   chainID: "phoenix-1",
   gasPrices: { uluna: 0.015 },
   gasAdjustment: 1.4,

--- a/docs/develop/terra-js/getting-started.md
+++ b/docs/develop/terra-js/getting-started.md
@@ -71,7 +71,7 @@ Terra’s LCD or Light Client Daemon allows users to connect to the blockchain, 
    const gasPricesJson = await gasPrices.json();
    const gasPricesCoins = new Coins(gasPricesJson);
    const lcd = new LCDClient({
-     URL: "https://pisco-lcd.terra.dev", // Use "https://lcd.terra.dev" for prod "http://localhost:1317" for localterra.
+     URL: "https://pisco-lcd.terra.dev", // Use "https://phoenix-lcd.terra.dev" for prod "http://localhost:1317" for localterra.
      chainID: "pisco-1", // Use "phoenix-1" for production or "localterra".
      gasPrices: gasPricesCoins,
      gasAdjustment: "1.5", // Increase gas price slightly so transactions go through smoothly.
@@ -82,7 +82,7 @@ Terra’s LCD or Light Client Daemon allows users to connect to the blockchain, 
    ::: {admonition} Switching to LocalTerra or the mainnet
    :class: note
 
-   The previous code block shows how to connect to the pisco testnet. To connect to LocalTerra, change the `URL` to `”http://localhost:1317”`. To connect to the phoenix-1 mainnet for production, use “`https://lcd.terra.dev`”.
+   The previous code block shows how to connect to the pisco testnet. To connect to LocalTerra, change the `URL` to `”http://localhost:1317”`. To connect to the phoenix-1 mainnet for production, use “`https://phoenix-lcd.terra.dev`”.
 
    You will also need to change the `chainID` from `"pisco-1"` to `”localterra”` or `"phoenix-1"`.
    :::

--- a/docs/develop/terra-js/make-a-connection.md
+++ b/docs/develop/terra-js/make-a-connection.md
@@ -13,7 +13,7 @@ To perform these actions, connect to the blockchain by using an `LCDClient` obje
 import { LCDClient } from "@terra-money/terra.js";
 
 const terra = new LCDClient({
-  URL: "https://lcd.terra.dev",
+  URL: "https://phoenix-lcd.terra.dev",
   chainID: "phoenix-1",
 });
 ```

--- a/docs/develop/terra-js/wallets.md
+++ b/docs/develop/terra-js/wallets.md
@@ -8,7 +8,7 @@ Use `LCDClient.wallet()` to create a `Wallet` from a `Key`.
 import { LCDClient, MnemonicKey } from "@terra-money/terra.js";
 
 const terra = new LCDClient({
-  URL: "https://lcd.terra.dev",
+  URL: "https://phoenix-lcd.terra.dev",
   chainId: "phoenix-1",
 });
 

--- a/docs/develop/terra-py/get-started-py.md
+++ b/docs/develop/terra-py/get-started-py.md
@@ -92,7 +92,7 @@ from terra_sdk.client.lcd import LCDClient
 
 # Create client to communicate with mainnet.
 terra = LCDClient(
-    url="https://lcd.terra.dev",
+    url="https://phoenix-lcd.terra.dev",
     chain_id="phoenix-1"
 )
 

--- a/docs/develop/vesting.md
+++ b/docs/develop/vesting.md
@@ -19,7 +19,7 @@ Vesting tokens will be stored in a type of vesting account available in one's wa
 One may view their respective vesting account information by adding their personal wallet address to the end of the below URL. For example, if one's personal wallet address were `terra111111111111111111111111111111111111111`, they would utilize the following URL to view their vesting account:
 
 ```
-https://lcd.terra.dev/cosmos/auth/v1beta1/accounts/terra111111111111111111111111111111111111111
+https://phoenix-lcd.terra.dev/cosmos/auth/v1beta1/accounts/terra111111111111111111111111111111111111111
 ```
 
 **Note:** Token amounts in the examples below will be given in microunits. To convert microunits to basic units, you can divide the specified quantities by 1,000,000. Time values utilized will be in Unix time. You may use [this converter](https://www.epochconverter.com/) to translate from Unix time to a human-readable datetime.

--- a/docs/migration/exchange-faq.md
+++ b/docs/migration/exchange-faq.md
@@ -189,16 +189,16 @@ It is up to each team. Each token team will have to relaunch the token to the ne
 ### I want to ignore multisig txs, could you share a mainnet example of this?
 
 - New format:
-https://lcd.terra.dev/cosmos/tx/v1beta1/txs/8F0A6782D22855C168C5C153CB17815512EB6159C740D669D665150128DC9BF0
+https://phoenix-lcd.terra.dev/cosmos/tx/v1beta1/txs/136825A738053AC6B7E8D03FB1C43696BA560AD9A8D5DB8AE49C55642CE64310
 
 - Old format:
-https://lcd.terra.dev/txs/8F0A6782D22855C168C5C153CB17815512EB6159C740D669D665150128DC9BF0
+https://phoenix-lcd.terra.dev/txs/136825A738053AC6B7E8D03FB1C43696BA560AD9A8D5DB8AE49C55642CE64310
 
 Please visit https://docs.terra.money/docs/develop/guides/sign-with-multisig.html for more info. 
 
 ### How do I get the "threshold number of signatures"?
 
-Use the following: https://lcd.terra.dev/cosmos/auth/v1beta1/accounts/terra1dp0taj85ruc299rkdvzp4z5pfg6z6swaed74e6
+Use the following: https://phoenix-lcd.terra.dev/cosmos/auth/v1beta1/accounts/terra14g48gms0zr29wufgyvz5smh8enaes9dh3rxxjh
 
 ### Is the "@type" of multisig tx always "bank/MsgSend"?
 


### PR DESCRIPTION
Update mainnet LCD to https://phoenix-lcd.terra.dev where it was pointing to old mainnet LCD https://lcd.terra.dev.