### PR TITLE
feat: Update Terrain docs for new client generation.

### DIFF
--- a/docs/develop/terrain/using-terrain-localterra.md
+++ b/docs/develop/terrain/using-terrain-localterra.md
@@ -104,7 +104,7 @@ The following structure shows your scaffolded project:
 To deploy the application, run the following command:
 
 ```sh
-terrain deploy my_terra_dapp --signer test1
+terrain deploy my_terra_dapp
 ```
 
 The deploy command performs the following steps automatically:
@@ -120,7 +120,19 @@ The deploy command performs the following steps automatically:
 If you are running LocalTerra and the previous `deploy` command is not working, try increasing Docker's memory allowance by clicking on the Docker icon. Click **Preferences** and then **Resources**. Increase the memory to at least 4 gigs. Click **Apply & Restart**. Run the deploy command again. You can increase again to 6 gigs if you are still having trouble. 
 :::
 
-## 3. Interact with the deployed contract
+## 3. Generate TypeScript client
+
+Terrain 0.5.x and above includes the ability to automatically generate a TypeScript client based on your smart contract schema. 
+
+Generating a client is easy, just run the following command: 
+
+```
+terrain contract:generateClient my_terra_dapp --build-schema
+```
+
+The generated client will be put in `./lib/clients` and copied to the frontend.
+
+## 4. Interact with the deployed contract
 
 The template comes with several predefined helpers in `lib/index.ts`. Use them to start interacting with your smart contract:
 
@@ -152,7 +164,7 @@ The template comes with several predefined helpers in `lib/index.ts`. Use them t
 Before proceeding to the next section, kill the running command in your terminal by entering "Ctrl + C" . 
 :::
 
-## 4. Front-end scaffolding
+## 5. Front-end scaffolding
 
 Terrain also scaffolds a very simple front-end:
 
@@ -161,7 +173,6 @@ Terrain also scaffolds a very simple front-end:
 2. To use the front end, run the following commands in order. The `terrain sync-refs` command copies your deployed contract addresses to the front-end part of the codebase.
 
    ```
-   terrain sync-refs
    cd frontend
    npm install
    npm start

--- a/docs/develop/terrain/using-terrain-testnet.md
+++ b/docs/develop/terrain/using-terrain-testnet.md
@@ -89,46 +89,29 @@ CLIError: account sequence mismatch, expected 1, got 0: incorrect account sequen
 Wait a few seconds then try the deploy command again.
 :::
 
-### Deploying with Terra Station
+## 3. Generate TypeScript client
 
-Besides the CLI approach above, there is also the option of deploying and interacting with your contracts on testnet through the [Terra Station UI](https://station.terra.money/).
+Terrain 0.5.x and above includes the ability to automatically generate a TypeScript client based on your smart contract schema. 
 
-1. Compile your project with `terrain`. If you have localterra running, this can be done with `terrain deploy <project> --signer test1`. This will build the wasm bytecode and output a **.wasm** file such as **artifacts/counter.wasm**
+Generating a client is easy, just run the following command: 
 
-2. You can now upload this contract to the testnet via Station. Go to [https://station.terra.money/contract](https://station.terra.money/contract) and click on "Upload"
+```
+terrain contract:generateClient my_terra_dapp --build-schema
+```
 
-3. Upload the .wasm bytecode. This step will generate a `codeId` which will be used for initializing the contract.
-
-4. Go back to the Contract page on [Station](https://station.terra.money/contract) and instantiate your contract by passing in the `codeId` and parameter (`{ "count": 0 }`) for "Init msg".
-
-5. Now, the contract is deployed as a **MsgInstantiateContract** transaction type. You will be able to see the address of the newly initialized contract in the logs at the bottom of the transaction details. ([example](https://finder.terra.money/testnet/tx/FF669A3E0CECDC6278A0E390FAF93E9531F43599B77A45BD18ECC6023E15ACB3))
-
-6. Search for your contract address on the **Contract** page of Terra Station. You can now execute a query or command against your contract. The payloads must be in JSON format. A command execution (with Execute) might look like:
-
-   ```sh
-   {
-     "increment": {}
-   }
-   ```
-
-   :::{admonition} Optional
-   :class: note
-   If you have a frontend, update your client-side `refs.terrain.json` to reflect the latest codeId and deployed contract address.
-   :::
+The generated client will be put in `./lib/clients` and copied to the frontend.
 
 ## 4. Interact with the deployed contract
 
 The Terrain template comes with several predefined helpers in `lib/index.js`. Use them to start interacting with your smart contract:
 
-1. Run `terrain console --network testnet`.
+1. Run `terrain console --network testnet --signer pisco`.
 
 2. With the console open, increment the counter by running the following:
 
    ```JavaScript
-   await lib.increment(wallets.pisco);
+   await lib.increment();
    ```
-
-   Make sure to pass your Pisco wallet to the increment command. `terrain console` makes wallets specified in `keys.terrain.js` available in the `wallets` object.
 
    You can get the current count by using:
 


### PR DESCRIPTION
Small updates related to Terrain 0.5.x! 

* Deploy no longer requires a signer, it defaults to test1. 
* For console to work now the user will need to generate the TypeScript client.
* `terrain console` now requires a signer for testnet, it defaults to test1 as well.
* lib functions no longer accept a wallet, so no more `await lib.increment(wallets.pisco);`. Instead you pass the wallet in the `--signer` flag. 