### PR TITLE
fix: station links

### DIFF
--- a/docs/develop/terra-js/getting-started.md
+++ b/docs/develop/terra-js/getting-started.md
@@ -89,7 +89,7 @@ Terra’s LCD or Light Client Daemon allows users to connect to the blockchain, 
 
 ## 3. Create a pisco testnet wallet
 
-1. You'll need a wallet to sign and submit transactions. [Create a new wallet](../../learn/terra-station/download/terra-station-extension.md) using the Terra Station extension. Be sure to save your mnemonic key!
+1. You'll need a wallet to sign and submit transactions. [Create a new wallet](../../learn/terra-station/download/terra-station-chrome.md) using the Terra Station extension. Be sure to save your mnemonic key!
 
 2. After creating your wallet, you’ll need to set it to use the testnet. Click the gear icon in the extension and change the network from `mainnet` to `testnet`.
 

--- a/docs/develop/terrain/cw20-factory.md
+++ b/docs/develop/terrain/cw20-factory.md
@@ -8,7 +8,7 @@ Use the following guides to set up your environment:
 
 - [Set up Terrain](./initial-setup.md)
 - [Set up LocalTerra](./using-terrain-localterra.md#install-and-run-localterra)
-- [Set up a Terra Station wallet extension](../../learn/terra-station/download/terra-station-extension.md)
+- [Set up a Terra Station wallet extension](../../learn/terra-station/download/terra-station-chrome.md)
 
 You'll also need: 
 

--- a/docs/develop/terrain/mint-an-nft.md
+++ b/docs/develop/terrain/mint-an-nft.md
@@ -7,8 +7,8 @@ In this tutorial, you will learn how to mint your own NFT using the [NFT Terrain
 ## Prerequisites
  
 - [Download Google Chrome](https://www.google.com/chrome/downloads/)
-- [Download the Terra Station extension](../../learn/terra-station/download/terra-station-extension.md)
-- [Create a Terra Station wallet](../../learn/terra-station/download/terra-station-extension.md)
+- [Download the Terra Station extension](../../learn/terra-station/download/terra-station-chrome.md)
+- [Create a Terra Station wallet](../../learn/terra-station/download/terra-station-chrome.md)
 - [Install npm](https://kinsta.com/blog/how-to-install-node-js/)
 - [Install git](https://git-scm.com/downloads)
 - [Install Terrain](initial-setup.md)

--- a/docs/develop/terrain/using-terrain-localterra.md
+++ b/docs/develop/terrain/using-terrain-localterra.md
@@ -7,7 +7,7 @@ LocalTerra is a complete Terra testnet and ecosystem containerized with Docker. 
 - [Docker](https://www.docker.com/)
 - [`docker-compose`](https://github.com/docker/compose)
 - At least 16 GB of RAM
-- [Terra Station Chrome extension](../../learn/terra-station/download/terra-station-extension.md)
+- [Terra Station Chrome extension](../../learn/terra-station/download/terra-station-chrome.md)
 - Node.js version 16
 
 :::{admonition} Node version error

--- a/docs/develop/terrain/using-terrain-testnet.md
+++ b/docs/develop/terrain/using-terrain-testnet.md
@@ -4,11 +4,11 @@ The [Pisco testnet](../../learn/glossary.md#testnet) is used for testing transac
 
 ## Prerequisites
 
-- [Install the Terra Station browser extension](../../learn/terra-station/download/terra-station-extension.md)
+- [Install the Terra Station browser extension](../../learn/terra-station/download/terra-station-chrome.md)
 
 ## Create a Pisco wallet
 
-[Create a new wallet](../../learn/terra-station/download/terra-station-extension.md#create-a-wallet) using the Terra Station extension. It's recommended that you name this wallet "Pisco" or "testnet" so it's easy to remember.
+[Create a new wallet](../../learn/terra-station/download/terra-station-chrome.md#create-a-wallet) using the Terra Station extension. It's recommended that you name this wallet "Pisco" or "testnet" so it's easy to remember.
 
 After creating a Pisco wallet and storing the seed phrase, request funds from the testnet faucet:
 

--- a/docs/develop/wallet-provider/wallet-provider-tutorial.md
+++ b/docs/develop/wallet-provider/wallet-provider-tutorial.md
@@ -13,7 +13,7 @@ If you're using a frontend framework other than React you'll need to use [Wallet
 
 ## Prerequisites
 
-- [Terra Station Chrome extension](../../learn/terra-station/download/terra-station-extension.md)
+- [Terra Station Chrome extension](../../learn/terra-station/download/terra-station-chrome.md)
 - Node.js version 16+
 - [NPM](https://www.npmjs.com/)
 

--- a/docs/ecosystem/explore.md
+++ b/docs/ecosystem/explore.md
@@ -149,7 +149,7 @@
 ## Wallets
 
 [Terra Station](https://station.terra.money/): Terra’s native wallet<br>
-Terra Station Extension: [Chrome](https://chrome.google.com/webstore/detail/terra-station/aiifbnbfobpmeekipheeijimdpnlpgpp)<br>
+Terra Station Extension: [Chrome](https://chrome.google.com/webstore/detail/terra-station/aiifbnbfobpmeekipheeijimdpnlpgpp) | [Firefox](https://addons.mozilla.org/en-US/firefox/addon/terra-station-wallet/)<br>
 Terra Station Desktop: [MacOS](https://github.com/terra-money/station-legacy/releases/download/v3.5.0/Terra.Station-1.1.0.dmg) | [Windows](https://github.com/terra-money/station-legacy/releases/download/v3.5.0/Terra.Station.Setup.1.1.0.exe) | [Linux (deb)](https://github.com/terra-money/station-legacy/releases/download/v3.5.0/station-electron_1.1.1_amd64.deb) | [Linux (rpm)](https://github.com/terra-money/station-legacy/releases/download/v3.5.0/station-electron-1.1.1.x86_64.rpm)<br>
 Terra Station Mobile: [iOS](https://apps.apple.com/app/id1548434735) | [Android](https://play.google.com/store/apps/details?id=money.terra.station)<br>
 [MathWallet](https://mathwallet.org/en-us/): multi-platform crypto wallet for Terra assets<br>

--- a/docs/ecosystem/integrations.md
+++ b/docs/ecosystem/integrations.md
@@ -250,7 +250,7 @@ Luna and Terra stablecoins are traded on the following exchanges:
 ## Wallets
 
 [Terra Station](https://station.terra.money/): Terra’s native wallet<br>
-Terra Station Extension: [Chrome](https://chrome.google.com/webstore/detail/terra-station/aiifbnbfobpmeekipheeijimdpnlpgpp)<br>
+Terra Station Extension: [Chrome](https://chrome.google.com/webstore/detail/terra-station/aiifbnbfobpmeekipheeijimdpnlpgpp) | [Firefox](https://addons.mozilla.org/en-US/firefox/addon/terra-station-wallet/)<br>
 Terra Station Desktop: [MacOS](https://github.com/terra-money/station-legacy/releases/download/v3.5.0/Terra.Station-1.1.0.dmg) | [Windows](https://github.com/terra-money/station/releases/download/v3.5.0/Terra.Station.Setup.1.1.0.exe) | [Linux (deb)](https://github.com/terra-money/station/releases/download/v3.5.0/station-electron_1.1.1_amd64.deb) | [Linux (rpm)](https://github.com/terra-money/station/releases/download/v3.5.0/station-electron-1.1.1.x86_64.rpm)<br>
 Terra Station Mobile: [iOS](https://apps.apple.com/app/id1548434735) | [Android](https://play.google.com/store/apps/details?id=money.terra.station)<br>
 [MathWallet](https://mathwallet.org/en-us/): multi-platform crypto wallet for Terra assets<br>

--- a/docs/learn/terra-station/download/README.md
+++ b/docs/learn/terra-station/download/README.md
@@ -4,7 +4,8 @@
 :hidden:
 :caption: Download Terra Station
 terra-station-desktop
-terra-station-extension
+terra-station-chrome
+terra-station-firefox
 terra-station-mobile
 ```
 :::{include} terra-station-desktop.md

--- a/docs/learn/terra-station/download/terra-station-chrome.md
+++ b/docs/learn/terra-station/download/terra-station-chrome.md
@@ -11,7 +11,7 @@ Desktop
 :::
 
 :::{grid-item}
-```{button-link} terra-station-extension.html
+```{button-link} terra-station-chrome.html
 :color: primary
 Chrome extension
 ```

--- a/docs/learn/terra-station/download/terra-station-desktop.md
+++ b/docs/learn/terra-station/download/terra-station-desktop.md
@@ -10,7 +10,7 @@ Desktop
 :::
 
 :::{grid-item}
-```{button-link} terra-station-extension.html
+```{button-link} terra-station-chrome.html
 :color: primary
 :outline:
 Chrome extension
@@ -200,6 +200,6 @@ After a few moments, the tokens will appear in the receiver's wallet.
 
 ## Next steps
 
-To start using any of the many dApps the Terra ecosystem has to offer, check out the [Terra Station Chrome browser extension](terra-station-extension.md). For on-the-go transactions, check out the [Terra Station mobile app](terra-station-mobile.md).
+To start using any of the many dApps the Terra ecosystem has to offer, check out the [Terra Station Chrome browser extension](terra-station-chrome.md). For on-the-go transactions, check out the [Terra Station mobile app](terra-station-mobile.md).
 
 For more guides on how to use other Station features, visit the [Station guides](../README.md).

--- a/docs/learn/terra-station/download/terra-station-firefox.md
+++ b/docs/learn/terra-station/download/terra-station-firefox.md
@@ -11,7 +11,7 @@ Desktop
 :::
 
 :::{grid-item}
-```{button-link} terra-station-extension.html
+```{button-link} terra-station-chrome.html
 :color: primary
 :outline:
 Chrome extension

--- a/docs/learn/terra-station/download/terra-station-mobile.md
+++ b/docs/learn/terra-station/download/terra-station-mobile.md
@@ -11,7 +11,7 @@ Desktop
 :::
 
 ::: {grid-item}
-```{button-link} terra-station-extension.html
+```{button-link} terra-station-chrome.html
 :color: primary
 :outline:
 Chrome extension

--- a/docs/learn/terra-station/keplr.md
+++ b/docs/learn/terra-station/keplr.md
@@ -5,9 +5,9 @@ Use this guide to connect your Terra Station wallet to a Keplr wallet using a Ch
 ## Prerequisites
 
 - Download [Google Chrome](https://www.google.com/chrome/).
-- Download the [Terra Station Chrome extension](download/terra-station-extension.md) and [create a wallet](download/terra-station-extension.md#create-a-wallet).
+- Download the [Terra Station Chrome extension](download/terra-station-chrome.md) and [create a wallet](download/terra-station-chrome.md#create-a-wallet).
 - Make sure you have a copy of your seed phrase written down.
-- [Purchase LUNA](download/terra-station-extension.md#buy-tokens-from-an-exchange) or other tokens to fill your wallet.
+- [Purchase LUNA](download/terra-station-chrome.md#buy-tokens-from-an-exchange) or other tokens to fill your wallet.
 
 ## Download Keplr
 

--- a/docs/learn/terra-station/multisig.md
+++ b/docs/learn/terra-station/multisig.md
@@ -6,7 +6,7 @@ Multisig wallets enable a wallet to be controlled by multiple parties. A wallet 
 
 ## Prerequisites
 
-- Download the [Terra Station browser extension](download/terra-station-extension.md)
+- Download the [Terra Station browser extension](download/terra-station-chrome.md)
 
 ## Create a multisig wallet
 

--- a/docs/learn/terra-station/wormhole.md
+++ b/docs/learn/terra-station/wormhole.md
@@ -6,7 +6,7 @@ Use this tutorial to bridge your assets between Terra and other chains using Wor
 
 ## Prerequisites
 
-- [The Terra Station browser extension](../terra-station/download/terra-station-extension.md) for tokens on the Terra blockchain.
+- [The Terra Station browser extension](../terra-station/download/terra-station-chrome.md) for tokens on the Terra blockchain.
 - A wallet on the chain you want to bridge. 
 
    :::{admonition} Paying for fees


### PR DESCRIPTION
Fixing the download station links in the nav bar as well as the linked buttons in the grid on each station download page.  Adding the Firefox extension option to docs/ecosystem/explore and docs/ecosystem/integrations.