### PR TITLE
Update build-terra-core.mdx

### DIFF
--- a/docs/full-node/run-a-full-terra-node/build-terra-core.mdx
+++ b/docs/full-node/run-a-full-terra-node/build-terra-core.mdx
@@ -15,9 +15,9 @@ Terra Core is the official Golang reference implementation of the Terra node sof
 If you are syncing a node from genesis you will need to use the appropriate core version for the block height of the respective chain you are syncing.
 
 | Network       | Type    | Core Version at Genesis | Block Height where core version changes        | Core version to use after fork height                                                                             |
-| :-------------| :------ | :------------------------------------------------------------------------------------------------ | :--------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------- |
-| `phoenix-1`   | Mainnet | v2.0.0                      |  890000                                        | v2.1.1             |
-| `pisco-1`     | Testnet | v2.0.0-rc.0                 |  838500                                        | 2.1.0-beta.1       |
+| :---------------| :------ | :------------------------------------------------------------------------------------------------ | :--------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------- |
+| `phoenix-1`     | Mainnet | v2.0.0                      |  890000                                        | v2.1.1             |
+| `pisco-1`       | Testnet | v2.0.0-rc.0                 |  838500                                        | 2.1.0-beta.1       |
 
 </Admonition>
 

--- a/docs/full-node/run-a-full-terra-node/build-terra-core.mdx
+++ b/docs/full-node/run-a-full-terra-node/build-terra-core.mdx
@@ -10,6 +10,18 @@ Terra Core is the official Golang reference implementation of the Terra node sof
 
 ## Get the Terra Core source code
 
+<Admonition type="tip" icon="💡" title="Core versions and heights">
+
+If you are syncing a node from genesis you will need to use the appropriate core version for the block height of the respective chain you are syncing.
+
+| Network       | Type    | Core Version at Genesis | Block Height where core version changes        | Core version to use after fork height                                                                             |
+| :----------   | :------ | :------------------------------------------------------------------------------------------------ | :--------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------- |
+| `phoenix-1`   | Mainnet | v2.0.0                      |  890000                                        | v2.1.1             |
+| `pisco-1`     | Testnet | v2.0.0-rc.0                 |  838500                                        | 2.1.0-beta.1       |
+
+</Admonition>
+
+
 1. Use `git` to retrieve [Terra Core](https://github.com/terra-money/core/), and check out the `main` branch, which contains the latest stable release. You can find the latest tag on the [tags page](https://github.com/terra-money/core/tags) or via autocomplete in your terminal: type `git checkout v` and press `<TAB>`.
 
    ```

--- a/docs/full-node/run-a-full-terra-node/build-terra-core.mdx
+++ b/docs/full-node/run-a-full-terra-node/build-terra-core.mdx
@@ -14,7 +14,7 @@ Terra Core is the official Golang reference implementation of the Terra node sof
 
 If you are syncing a node from genesis you will need to use the appropriate core version for the block height of the respective chain you are syncing.
 
-| Network       | Type    | Core Version at Genesis | Block Height where core version changes        | Core version to use after fork height                                                                             |
+| Network       | Type    | Core Version at Genesis | Fork height        | Core version after fork height                                                                             |
 | :---------------| :------ | :------------------------------------------------------------------------------------------------ | :--------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------- |
 | `phoenix-1`     | Mainnet | v2.0.0                      |  890000                                        | v2.1.1             |
 | `pisco-1`       | Testnet | v2.0.0-rc.0                 |  838500                                        | 2.1.0-beta.1       |

--- a/docs/full-node/run-a-full-terra-node/build-terra-core.mdx
+++ b/docs/full-node/run-a-full-terra-node/build-terra-core.mdx
@@ -15,7 +15,7 @@ Terra Core is the official Golang reference implementation of the Terra node sof
 If you are syncing a node from genesis you will need to use the appropriate core version for the block height of the respective chain you are syncing.
 
 | Network       | Type    | Core Version at Genesis | Block Height where core version changes        | Core version to use after fork height                                                                             |
-| :----------   | :------ | :------------------------------------------------------------------------------------------------ | :--------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------- |
+| :-------------| :------ | :------------------------------------------------------------------------------------------------ | :--------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------- |
 | `phoenix-1`   | Mainnet | v2.0.0                      |  890000                                        | v2.1.1             |
 | `pisco-1`     | Testnet | v2.0.0-rc.0                 |  838500                                        | 2.1.0-beta.1       |
 


### PR DESCRIPTION
@terran6 looking to put this table in a tip box. If you are able to edit this PR to correct the Admonition, or present info in a better way.


<Admonition type="tip" icon="💡" title="Core versions and heights">

If you are syncing a node from genesis you will need to use the appropriate core version for the block height of the respective chain you are syncing.

| Network       | Type    | Core Version at Genesis | Block Height where core version changes        | Core version to use after fork height                                                                             |
| :----------   | :------ | :------------------------------------------------------------------------------------------------ | :--------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------- |
| `phoenix-1`   | Mainnet | v2.0.0                      |  890000                                        | v2.1.1             |
| `pisco-1`     | Testnet | v2.0.0-rc.0                 |  838500                                        | 2.1.0-beta.1       |

</Admonition>