### PR TITLE
docs: updating node sync instructions

### DIFF
--- a/docs/full-node/run-a-full-terra-node/join-a-network.mdx
+++ b/docs/full-node/run-a-full-terra-node/join-a-network.mdx
@@ -96,7 +96,7 @@ Choose a `testnet` or `mainnet` address type and download the appropriate genesi
 
 ```bash
 # Obtain the genesis for phoenix-1:
-wget hhttps://phoenix-genesis.s3.us-west-1.amazonaws.com/genesis.json -I ~/.terra/config/genesis.json
+wget https://phoenix-genesis.s3.us-west-1.amazonaws.com/genesis.json -O ~/.terra/config/genesis.json
 
 # Obtain the addressbook for the phoenix-1 from Polkachu:
 wget https://snapshots1.polkachu.com/addrbook/terra/addrbook.json -O ~/.terra/config/addrbook.json

--- a/docs/full-node/run-a-full-terra-node/join-a-network.mdx
+++ b/docs/full-node/run-a-full-terra-node/join-a-network.mdx
@@ -96,7 +96,7 @@ Choose a `testnet` or `mainnet` address type and download the appropriate genesi
 
 ```bash
 # Obtain the genesis for phoenix-1:
-wget hhttps://phoenix-genesis.s3.us-west-1.amazonaws.com/genesis.json -I ~/.terra/config/genesis.json
+wget https://phoenix-genesis.s3.us-west-1.amazonaws.com/genesis.json -I ~/.terra/config/genesis.json
 
 # Obtain the addressbook for the phoenix-1 from Polkachu:
 wget https://snapshots1.polkachu.com/addrbook/terra/addrbook.json -O ~/.terra/config/addrbook.json

--- a/docs/full-node/run-a-full-terra-node/sync.mdx
+++ b/docs/full-node/run-a-full-terra-node/sync.mdx
@@ -14,7 +14,7 @@ The process for syncing your full node from genesis will differ between the Pisc
 
 ### Pisco testnet
 
-If you would like to sync your node using the Pisco testnet, you will need to utilize version `v2.0.0-rc.0` of terrad up until the block height of 890,000. To sync your node from block 890,000 onward, you will need to utilize version `v2.1.0-beta.1` of terrad. 
+If you would like to sync your node using the Pisco testnet, you will need to utilize version `v2.0.0-rc.0` of terrad up until the block height of 838,500. To sync your node from block 838,500 onward, you will need to utilize version `v2.1.0-beta.1` of terrad. 
 
 1. To switch to version `v2.0.0-rc.0` of terrad, [change into your `core` directory](./build-terra-core.mdx#get-the-terra-core-source-code) and execute the following commands in your terminal:
 
@@ -49,9 +49,9 @@ Nodes take at least an hour to start syncing. This wait time is normal. Before t
 
 </Admonition>
 
-Syncing will halt at block 890,000, at which point you will need to change the version of terrad and then resume the syncing process. 
+Syncing will halt at block 838,500, at which point you will need to change the version of terrad and then resume the syncing process. 
 
-4. To sync your Pisco testnet node from block 890,000 to the most recent block, you will need to navigate to the `core` directory and change your terrad version to `v2.1.0-beta.1`.
+4. To sync your Pisco testnet node from block 838,500 to the most recent block, you will need to navigate to the `core` directory and change your terrad version to `v2.1.0-beta.1`.
 
 ```
 git checkout v2.1.0-beta.1
@@ -76,7 +76,7 @@ From here, you can [monitor the sync](#monitor-the-sync). Make sure to check on 
 
 ### Phoenix mainnet
 
-If you would like to sync your node using the Phoenix mainnet, you will need to utilize version `v2.0.0` of terrad up until the block height of 838,500. To sync your node from block 838,500 onward, you will need to utilize version `v2.1.1` of terrad.  
+If you would like to sync your node using the Phoenix mainnet, you will need to utilize version `v2.0.0` of terrad up until the block height of 890,000. To sync your node from block 890,000 onward, you will need to utilize version `v2.1.1` of terrad.  
 
 1. To switch to version `v2.0.0` of terrad, [change into your `core` directory](./build-terra-core.mdx#get-the-terra-core-source-code) and execute the following commands in your terminal:
 
@@ -111,9 +111,9 @@ Nodes take at least an hour to start syncing. This wait time is normal. Before t
 
 </Admonition>
 
-Syncing will halt at block 838,500, at which point you will need to change the version of terrad and then resume the syncing process. 
+Syncing will halt at block 890,000, at which point you will need to change the version of terrad and then resume the syncing process. 
 
-4. To sync your Phoenix mainnet node from block 838,500 to the most recent block, you will need to navigate to the `core` directory and change your terrad version to `v2.1.1`.
+4. To sync your Phoenix mainnet node from block 890,000 to the most recent block, you will need to navigate to the `core` directory and change your terrad version to `v2.1.1`.
 
 ```
 git checkout v2.1.1

--- a/docs/full-node/run-a-full-terra-node/sync.mdx
+++ b/docs/full-node/run-a-full-terra-node/sync.mdx
@@ -6,22 +6,24 @@ import Admonition from '@theme/Admonition';
 
 # Sync
 
-This guide will walk you through how to [sync the chain from genesis](#sync-from-genesis) or use a [snapshot](#sync-from-snapshot) for a quicker sync. 
+This guide will walk you through how to [sync the chain from genesis](#sync-from-genesis) or use a [snapshot](#sync-from-snapshot) for a quicker sync. Before you start to sync your node, confirm that you have properly set up your [system configuration](./system-config.mdx#system-configuration) and [built Terra core](./build-terra-core.mdx#get-the-terra-core-source-code).
 
 ## Sync from genesis
 
-The process for syncing your full node from genesis will differ between the Pisco testnet and Phoenix-1 mainnet networks. You may proceed with the instructions corresponding with your [chosen network](./join-a-network.mdx#join-a-public-network) below.
+The process for syncing your full node from genesis will differ between the Pisco testnet and Phoenix mainnet networks. You may proceed with the instructions corresponding with your [chosen network](./join-a-network.mdx#join-a-public-network) below.
 
 ### Pisco testnet
 
-If you would like to sync your node using the Pisco testnet, you will need to utilize version `v2.0.0-rc.0` of Terrad up until the block height of 890,000.  To switch to this version of Terrad, change into your `core` directory and execute the following commands in your terminal:
+If you would like to sync your node using the Pisco testnet, you will need to utilize version `v2.0.0-rc.0` of terrad up until the block height of 890,000. To sync your node from block 890,000 onward, you will need to utilize version `v2.1.0-beta.1` of terrad. 
+
+1. To switch to version `v2.0.0-rc.0` of terrad, [change into your `core` directory](./build-terra-core.mdx#get-the-terra-core-source-code) and execute the following commands in your terminal:
 
 ```
 git checkout v2.0.0-rc.0
 make install
 ```
 
-After running these commands, make sure that you have switched to the correct version of Terrad by running the command:
+After running these commands, make sure that you have switched to the correct version of terrad by running the following command:
 
 ```
 terrad version
@@ -29,13 +31,13 @@ terrad version
 
 The result of this command should be `v2.0.0-rc.0`.
 
-After you have the correct Terrad version, you will need to download the genesis file for Pisco in the Terrad config directory:
+2. After you have the correct terrad version, you will need to download the genesis file for Pisco in the terrad config directory:
 
 ```
 wget https://raw.githubusercontent.com/terra-money/testnet/master/pisco-1/genesis.json -O ~/.terra/config/genesis.json
 ```
 
-Finally, you can start the syncing process:
+3. Finally, you can start the syncing process:
 
 ```
 terrad start
@@ -47,16 +49,16 @@ Nodes take at least an hour to start syncing. This wait time is normal. Before t
 
 </Admonition>
 
-Syncing will halt at block 890,000, at which point you will need to change the version of Terrad and then resume the syncing process. 
+Syncing will halt at block 890,000, at which point you will need to change the version of terrad and then resume the syncing process. 
 
-To sync your Pisco testnet node from block 890,000 to the most recent block, you will need to navigate to the `core` directory and change your Terrad version to `v2.1.0-beta.1`.
+4. To sync your Pisco testnet node from block 890,000 to the most recent block, you will need to navigate to the `core` directory and change your terrad version to `v2.1.0-beta.1`.
 
 ```
 git checkout v2.1.0-beta.1
 make install
 ```
 
-Again, make sure that you have switched to the correct version of Terrad by running the following command:
+Again, make sure that you have switched to the correct version of terrad by running the following command:
 
 ```
 terrad version
@@ -64,24 +66,26 @@ terrad version
 
 The result of this command should be `v2.1.0`.
 
-Now, you can resume the syncing process:
+5. Now, you can resume the syncing process:
 
 ```
 terrad start
 ```
 
-From here, you can [monitor the sync](#monitor-the-sync) and make sure to check on your node periodically to ensure optimal performance.
+From here, you can [monitor the sync](#monitor-the-sync). Make sure to check on your node periodically to ensure optimal performance.
 
-### Phoenix-1 mainnet
+### Phoenix mainnet
 
-If you would like to sync your node using the Phoenix-1 mainnet, you will need to utilize version `v2.0.0` of Terrad up until the block height of 838,500.  To switch to this version of Terrad, change into your `core` directory and execute the following commands in your terminal:
+If you would like to sync your node using the Phoenix mainnet, you will need to utilize version `v2.0.0` of terrad up until the block height of 838,500. To sync your node from block 838,500 onward, you will need to utilize version `v2.1.1` of terrad.  
+
+1. To switch to version `v2.0.0` of terrad, [change into your `core` directory](./build-terra-core.mdx#get-the-terra-core-source-code) and execute the following commands in your terminal:
 
 ```
 git checkout v2.0.0
 make install
 ```
 
-After running these commands, make sure that you have switched to the correct version of Terrad by running the command:
+After running these commands, make sure that you have switched to the correct version of terrad by running the following command:
 
 ```
 terrad version
@@ -89,13 +93,13 @@ terrad version
 
 The result of this command should be `v2.0.0`.
 
-After you have the correct Terrad version, you will need to download the genesis file for Phoenix-1 in the Terrad config directory:
+2. After you have the correct terrad version, you will need to download the genesis file for Phoenix in the terrad config directory:
 
 ```
 wget https://phoenix-genesis.s3.us-west-1.amazonaws.com/genesis.json -O ~/.terra/config/genesis.json
 ```
 
-Finally, you can start the syncing process:
+3. Finally, you can start the syncing process:
 
 ```
 terrad start
@@ -107,16 +111,16 @@ Nodes take at least an hour to start syncing. This wait time is normal. Before t
 
 </Admonition>
 
-Syncing will halt at block 838,500, at which point you will need to change the version of Terrad and then resume the syncing process. 
+Syncing will halt at block 838,500, at which point you will need to change the version of terrad and then resume the syncing process. 
 
-To sync your Phoenix-1 mainnet node from block 838,500 to the most recent block, you will need to navigate to the `core` directory and change your Terrad version to `v2.1.1`.
+4. To sync your Phoenix mainnet node from block 838,500 to the most recent block, you will need to navigate to the `core` directory and change your terrad version to `v2.1.1`.
 
 ```
 git checkout v2.1.1
 make install
 ```
 
-Again, make sure that you have switched to the correct version of Terrad by running the following command:
+Again, make sure that you have switched to the correct version of terrad by running the following command:
 
 ```
 terrad version
@@ -124,13 +128,13 @@ terrad version
 
 The result of this command should be `v2.1.1`.
 
-Now, you can resume the syncing process:
+5. Now, you can resume the syncing process:
 
 ```
 terrad start
 ```
 
-From here, you can [monitor the sync](#monitor-the-sync) and make sure to check on your node periodically to ensure optimal performance.
+From here, you can [monitor the sync](#monitor-the-sync). Make sure to check on your node periodically to ensure optimal performance.
 
 <details> 
 <summary> Healthy Node Status Example </summary>
@@ -197,7 +201,7 @@ terrad start --x-crisis-skip-assert-invariants
 
 ## Sync from snapshot
 
-You can significantly accelerate the synchronization process by providing Terrad with a recent snapshot of the network state. Snapshots are made publicly available by members of the Terra community one example can be downloaded from [Polkachu - Phoenix Mainnet](https://polkachu.com/state_sync/terra). [Polkachu - Pisco Testnet](https://polkachu.com/testnets/terraInstructions) are provided by Polkachu, and not maintained as part of this documentation.
+You can significantly accelerate the synchronization process by providing terrad with a recent snapshot of the network state. Snapshots are made publicly available by members of the Terra community one example can be downloaded from [Polkachu - Phoenix Mainnet](https://polkachu.com/state_sync/terra). [Polkachu - Pisco Testnet](https://polkachu.com/testnets/terraInstructions) are provided by Polkachu, and not maintained as part of this documentation.
 
 ### Before using snapshots
 
@@ -230,7 +234,7 @@ With an address book downloaded, run the following:
 ```bash
 terrad start
 terrad status
-# It will take a few seconds for Terrad to start.
+# It will take a few seconds for terrad to start.
 ```
 
 ## Monitor the sync

--- a/docs/full-node/run-a-full-terra-node/sync.mdx
+++ b/docs/full-node/run-a-full-terra-node/sync.mdx
@@ -32,8 +32,7 @@ The result of this command should be `v2.0.0-rc.0`.
 After you have the correct Terrad version, you will need to download the genesis file for Pisco in the Terrad config directory:
 
 ```
-cd ~/.terra/config/
-wget https://raw.githubusercontent.com/terra-money/testnet/master/pisco-1/genesis.json
+wget https://raw.githubusercontent.com/terra-money/testnet/master/pisco-1/genesis.json -O ~/.terra/config/genesis.json
 ```
 
 Finally, you can start the syncing process:
@@ -93,8 +92,7 @@ The result of this command should be `v2.0.0`.
 After you have the correct Terrad version, you will need to download the genesis file for Phoenix-1 in the Terrad config directory:
 
 ```
-cd ~/.terra/config/
-wget https://phoenix-genesis.s3.us-west-1.amazonaws.com/genesis.json
+wget https://phoenix-genesis.s3.us-west-1.amazonaws.com/genesis.json -O ~/.terra/config/genesis.json
 ```
 
 Finally, you can start the syncing process:

--- a/docs/full-node/run-a-full-terra-node/sync.mdx
+++ b/docs/full-node/run-a-full-terra-node/sync.mdx
@@ -6,25 +6,133 @@ import Admonition from '@theme/Admonition';
 
 # Sync
 
-Use this guide to [sync the chain from from genesis](#sync-from-genesis) or use a [snapshot](#sync-from-snapshot) for a quicker sync. 
+This guide will walk you through how to [sync the chain from genesis](#sync-from-genesis) or use a [snapshot](#sync-from-snapshot) for a quicker sync. 
 
 ## Sync from genesis
 
-After [choosing a network](./join-a-network.mdx#join-a-public-network), start the sync and check that everything is running smoothly:
+The process for syncing your full node from genesis will differ between the Pisco testnet and Phoenix-1 mainnet networks. You may proceed with the instructions corresponding with your [chosen network](./join-a-network.mdx#join-a-public-network) below.
 
-```bash
-terrad start
-terrad status
-# It will take a few seconds for Terrad to start.
+### Pisco testnet
+
+If you would like to sync your node using the Pisco testnet, you will need to utilize version `v2.0.0-rc.0` of Terrad up until the block height of 890,000.  To switch to this version of Terrad, change into your `core` directory and execute the following commands in your terminal:
+
 ```
-Your node is now syncing. This process will take a long time. Make sure you've set it up on a stable connection so this process is not interrupted.
+git checkout v2.0.0-rc.0
+make install
+```
 
+After running these commands, make sure that you have switched to the correct version of Terrad by running the command:
+
+```
+terrad version
+```
+
+The result of this command should be `v2.0.0-rc.0`.
+
+After you have the correct Terrad version, you will need to download the genesis file for Pisco in the Terrad config directory:
+
+```
+cd ~/.terra/config/
+wget https://raw.githubusercontent.com/terra-money/testnet/master/pisco-1/genesis.json
+```
+
+Finally, you can start the syncing process:
+
+```
+terrad start
+```
 
 <Admonition type="caution" icon="☢️" title="Sync start times">
 
 Nodes take at least an hour to start syncing. This wait time is normal. Before troubleshooting a sync, please wait an hour for the sync to start.
 
 </Admonition>
+
+Syncing will halt at block 890,000, at which point you will need to change the version of Terrad and then resume the syncing process. 
+
+To sync your Pisco testnet node from block 890,000 to the most recent block, you will need to navigate to the `core` directory and change your Terrad version to `v2.1.0-beta.1`.
+
+```
+git checkout v2.1.0-beta.1
+make install
+```
+
+Again, make sure that you have switched to the correct version of Terrad by running the following command:
+
+```
+terrad version
+```
+
+The result of this command should be `v2.1.0`.
+
+Now, you can resume the syncing process:
+
+```
+terrad start
+```
+
+From here, you can [monitor the sync](#monitor-the-sync) and make sure to check on your node periodically to ensure optimal performance.
+
+### Phoenix-1 mainnet
+
+If you would like to sync your node using the Phoenix-1 mainnet, you will need to utilize version `v2.0.0` of Terrad up until the block height of 838,500.  To switch to this version of Terrad, change into your `core` directory and execute the following commands in your terminal:
+
+```
+git checkout v2.0.0
+make install
+```
+
+After running these commands, make sure that you have switched to the correct version of Terrad by running the command:
+
+```
+terrad version
+```
+
+The result of this command should be `v2.0.0`.
+
+After you have the correct Terrad version, you will need to download the genesis file for Phoenix-1 in the Terrad config directory:
+
+```
+cd ~/.terra/config/
+wget https://phoenix-genesis.s3.us-west-1.amazonaws.com/genesis.json
+```
+
+Finally, you can start the syncing process:
+
+```
+terrad start
+```
+
+<Admonition type="caution" icon="☢️" title="Sync start times">
+
+Nodes take at least an hour to start syncing. This wait time is normal. Before troubleshooting a sync, please wait an hour for the sync to start.
+
+</Admonition>
+
+Syncing will halt at block 838,500, at which point you will need to change the version of Terrad and then resume the syncing process. 
+
+To sync your Phoenix-1 mainnet node from block 838,500 to the most recent block, you will need to navigate to the `core` directory and change your Terrad version to `v2.1.1`.
+
+```
+git checkout v2.1.1
+make install
+```
+
+Again, make sure that you have switched to the correct version of Terrad by running the following command:
+
+```
+terrad version
+```
+
+The result of this command should be `v2.1.1`.
+
+Now, you can resume the syncing process:
+
+```
+terrad start
+```
+
+From here, you can [monitor the sync](#monitor-the-sync) and make sure to check on your node periodically to ensure optimal performance.
 
 <details> 
 <summary> Healthy Node Status Example </summary>
@@ -74,8 +182,6 @@ Nodes take at least an hour to start syncing. This wait time is normal. Before t
 
 </p>
 </details>
-
-Proceed to the [Monitor the sync](#monitor-the-sync) section.
 
 ### Fast-sync for testing
 

--- a/docs/full-node/run-a-full-terra-node/sync.mdx
+++ b/docs/full-node/run-a-full-terra-node/sync.mdx
@@ -37,7 +37,9 @@ The result of this command should be `v2.0.0-rc.0`.
 wget https://raw.githubusercontent.com/terra-money/testnet/master/pisco-1/genesis.json -O ~/.terra/config/genesis.json
 ```
 
-3. Finally, you can start the syncing process:
+3. Next, [update the `persistent_peers` setting](https://polkachu.com/testnets/terra/peers) with a list of stable persistent peers in your `config.toml` file.
+
+4. Finally, you can start the syncing process:
 
 ```
 terrad start
@@ -51,7 +53,7 @@ Nodes take at least an hour to start syncing. This wait time is normal. Before t
 
 Syncing will halt at block 890,000, at which point you will need to change the version of terrad and then resume the syncing process. 
 
-4. To sync your Pisco testnet node from block 890,000 to the most recent block, you will need to navigate to the `core` directory and change your terrad version to `v2.1.0-beta.1`.
+5. To sync your Pisco testnet node from block 890,000 to the most recent block, you will need to navigate to the `core` directory and change your terrad version to `v2.1.0-beta.1`.
 
 ```
 git checkout v2.1.0-beta.1
@@ -66,7 +68,7 @@ terrad version
 
 The result of this command should be `v2.1.0`.
 
-5. Now, you can resume the syncing process:
+6. Now, you can resume the syncing process:
 
 ```
 terrad start
@@ -99,7 +101,13 @@ The result of this command should be `v2.0.0`.
 wget https://phoenix-genesis.s3.us-west-1.amazonaws.com/genesis.json -O ~/.terra/config/genesis.json
 ```
 
-3. Finally, you can start the syncing process:
+3. Next, download the `addrbook.json` file containing a list of stable persistent peers into the `~/.terra/config/` directory:
+
+```
+wget https://snapshots1.polkachu.com/addrbook/terra/addrbook.json -O ~/.terra/config/addrbook.json
+```
+
+4. Finally, you can start the syncing process:
 
 ```
 terrad start
@@ -113,7 +121,7 @@ Nodes take at least an hour to start syncing. This wait time is normal. Before t
 
 Syncing will halt at block 838,500, at which point you will need to change the version of terrad and then resume the syncing process. 
 
-4. To sync your Phoenix mainnet node from block 838,500 to the most recent block, you will need to navigate to the `core` directory and change your terrad version to `v2.1.1`.
+5. To sync your Phoenix mainnet node from block 838,500 to the most recent block, you will need to navigate to the `core` directory and change your terrad version to `v2.1.1`.
 
 ```
 git checkout v2.1.1
@@ -128,7 +136,7 @@ terrad version
 
 The result of this command should be `v2.1.1`.
 
-5. Now, you can resume the syncing process:
+6. Now, you can resume the syncing process:
 
 ```
 terrad start


### PR DESCRIPTION
Updating instructions on how to sync a node on Pisco testnet and Phoenix-1 mainnet.