### PR TITLE
docs: sync alert

### DIFF
--- a/docs/full-node/run-a-full-terra-node/sync.mdx
+++ b/docs/full-node/run-a-full-terra-node/sync.mdx
@@ -6,7 +6,13 @@ import Admonition from '@theme/Admonition';
 
 # Sync
 
-This guide will walk you through how to [sync the chain from genesis](#sync-from-genesis) or use a [snapshot](#sync-from-snapshot) for a quicker sync. Before you start to sync your node, confirm that you have properly set up your [system configuration](./system-config.mdx#system-configuration) and [built Terra core](./build-terra-core.mdx#get-the-terra-core-source-code).
+This guide will walk you through how to [sync the chain from genesis](#sync-from-genesis) or use a [snapshot](#sync-from-snapshot) for a quicker sync.
+
+<Admonition type="caution" icon="☢️" title="Setup for successful sync">
+
+Before you attempt to sync your node, confirm that you have properly set up your [system configuration](./system-config.mdx#system-configuration) and [built Terra core](./build-terra-core.mdx#get-the-terra-core-source-code).
+
+</Admonition>
 
 ## Sync from genesis
 


### PR DESCRIPTION
Adding "caution" Admonition to tell user to setup configuration and build Terra core before node sync.  Alert needed to draw user to read important information.