### PR TITLE
fix: naming in cw20 token factory tutorial

### DIFF
--- a/docs/develop/terrain/cw20-factory.mdx
+++ b/docs/develop/terrain/cw20-factory.mdx
@@ -420,15 +420,15 @@ cargo test
 
 </CH.Scrollycoding>
 
-### 4. Modify `terrain.config.json`
+### 4. Modify `config.terrain.json`
 
 <CH.Scrollycoding>
 
-1. Open _`terrain.config.json`_.
+1. Open _`config.terrain.json`_.
 
-2. Modify the _`InstantiateMsg`_ property in the _`terrain.config.json`_ so that it contains the _`name`_, _`symbol`_, _`decimals`_, and _`initial_balances`_ shown in the example. This allows you to send the correct data to the smart contract upon instantiation.
+2. Modify the _`InstantiateMsg`_ property in the _`config.terrain.json`_ so that it contains the _`name`_, _`symbol`_, _`decimals`_, and _`initial_balances`_ shown in the example. This allows you to send the correct data to the smart contract upon instantiation.
 
-```json terrain.config.json
+```json config.terrain.json
 {
   "_global": {
     "_base": {
@@ -508,7 +508,7 @@ To add the dependencies, do the following.
 cw2 = "0.13.2"
 cw20 = "0.13.2"
 cw20-base = {  version = "0.13.2", features = ["library"] }
-cw20_factory_token = {  version = "0.6.0", features = ["library"] }
+cw20-factory-token = {  version = "0.6.0", features = ["library"] }
 # ...
 ```
 
@@ -1390,9 +1390,9 @@ test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; fini
 
 </CH.Scrollycoding>
 
-### 4. Modify `terrain.config.json`
+### 4. Modify `config.terrain.json`
 
-1. Open _`terrain.config.json`_.
+1. Open _`config.terrain.json`_.
 
 2. Modify the property _`InstantiateMsg`_, using your _`<token_contract_code_id>`_. **The _`<token_contract_code_id>`_ should not be surrounded by quotes**.
 


### PR DESCRIPTION
1. `config.terrain.json` is the name generated by terrain, but the cw20 tutorial used `terrain.config.json`, either the doc is wrong or terrain is wrong. Just wanna raise awareness. 
2. `cw20_factory_token` is named as `cw20-factory-token` in [crates.io](https://crates.io/crates/cw20_factory_token), maybe we should change all naming to `cw20-factory-token` in the tutorial when creating this new contract.