### PR TITLE
style: Luna logo copyright

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -33,8 +33,8 @@ jobs:
       - name: Publish to Cloudflare Pages
         uses: cloudflare/pages-action@1
         with:
-          apiToken: ${{ secrets.CLOUDFLARE_PAGES_TOKEN }}
           accountId: 620ff29bbd515d2848f5306578bd1d1d
+          apiToken: ${{ secrets.CLOUDFLARE_PAGES_TOKEN }}
           projectName: docs-terra
           directory: build
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/src/styles/footer.scss
+++ b/src/styles/footer.scss
@@ -84,12 +84,4 @@
   .links {
     border-color: #343536;
   }
-
-  .copyright img {
-    width: 45px;
-    height: 45px;
-    box-sizing: border-box;
-    padding-left: 200px;
-    background: url(/img/Luna-color.svg) center top no-repeat;
-  }
 }

--- a/src/styles/footer.scss
+++ b/src/styles/footer.scss
@@ -84,4 +84,12 @@
   .links {
     border-color: #343536;
   }
+
+  .copyright img {
+    width: 45px;
+    height: 45px;
+    box-sizing: border-box;
+    padding-left: 200px;
+    background: url(/img/Luna-color.svg) center top no-repeat;
+  }
 }

--- a/src/theme/Link/Copyright.jsx
+++ b/src/theme/Link/Copyright.jsx
@@ -1,10 +1,16 @@
 import React from 'react';
+import ThemedImage from '@theme/ThemedImage';
 
 function Copyright() {
   return (
     <div className="copyright col">
       <a href='https://www.terra.money/'>
-        <img src='/img/icons/terraform-labs.svg' alt='Terraform Labs' />
+        <ThemedImage
+          sources={{
+            light:"/img/icons/terraform-labs.svg",
+            dark:"/img/Luna-color.svg"}}
+            height="40px"
+        />
       </a>
       <p style={{fontSize: '10px'}}>{`Copyright © ${new Date().getFullYear()} Terraform Labs`}</p>
     </div>


### PR DESCRIPTION
Luna logo for footer copyright in dark mode.

<img width="1004" alt="image" src="https://user-images.githubusercontent.com/30275692/197402983-56baf646-e317-45c9-ad67-25d51451def8.png">