### PR TITLE
fix: cw20 token factory naming, deps and unit test

### DIFF
--- a/docs/develop/terrain/cw20-factory.mdx
+++ b/docs/develop/terrain/cw20-factory.mdx
@@ -985,14 +985,14 @@ pub fn reply(deps: DepsMut, _env: Env, msg: Reply) -> StdResult<Response> {
 fn handle_instantiate_reply(deps: DepsMut, msg: Reply) -> StdResult<Response> {
     let result = msg.result.into_result().map_err(StdError::generic_err)?;
 
-    /* Find the event type instantiate which contains the contract_address*/
+    /* Find the event type instantiate_contract which contains the contract_address*/
     let event = result
         .events
         .iter()
         .find(|event| event.ty == "instantiate_contract")
         .ok_or_else(|| StdError::generic_err("cannot find `instantiate_contract` event"))?;
 
-    /* Find the _contract_address from instantiate event*/
+    /* Find the contract_address from instantiate_contract event*/
     let contract_address = &event
         .attributes
         .iter()
@@ -1276,7 +1276,7 @@ mod tests {
         execute(deps, env.clone(), info.clone(), msg).unwrap()
     }
 
-    /* Confirm reply event form instantiate method. That way
+    /* Confirm reply event from instantiate method. That way
     the minted_tokens addresses can be whitelisted in factory.*/
     fn do_reply_instantiate_event(deps: DepsMut) -> Response {
         let env = mock_env();

--- a/docs/develop/terrain/cw20-factory.mdx
+++ b/docs/develop/terrain/cw20-factory.mdx
@@ -420,15 +420,15 @@ cargo test
 
 </CH.Scrollycoding>
 
-### 4. Modify `terrain.config.json`
+### 4. Modify `config.terrain.json`
 
 <CH.Scrollycoding>
 
-1. Open _`terrain.config.json`_.
+1. Open _`config.terrain.json`_.
 
-2. Modify the _`InstantiateMsg`_ property in the _`terrain.config.json`_ so that it contains the _`name`_, _`symbol`_, _`decimals`_, and _`initial_balances`_ shown in the example. This allows you to send the correct data to the smart contract upon instantiation.
+2. Modify the _`InstantiateMsg`_ property in the _`config.terrain.json`_ so that it contains the _`name`_, _`symbol`_, _`decimals`_, and _`initial_balances`_ shown in the example. This allows you to send the correct data to the smart contract upon instantiation.
 
-```json terrain.config.json
+```json config.terrain.json
 {
   "_global": {
     "_base": {
@@ -508,7 +508,7 @@ To add the dependencies, do the following.
 cw2 = "0.13.2"
 cw20 = "0.13.2"
 cw20-base = {  version = "0.13.2", features = ["library"] }
-cw20_factory_token = {  version = "0.6.0", features = ["library"] }
+cw20-factory-token = {  version = "0.6.0", features = ["library"] }
 # ...
 ```
 
@@ -989,15 +989,15 @@ fn handle_instantiate_reply(deps: DepsMut, msg: Reply) -> StdResult<Response> {
     let event = result
         .events
         .iter()
-        .find(|event| event.ty == "instantiate")
-        .ok_or_else(|| StdError::generic_err("cannot find `instantiate` event"))?;
+        .find(|event| event.ty == "instantiate_contract")
+        .ok_or_else(|| StdError::generic_err("cannot find `instantiate_contract` event"))?;
 
     /* Find the _contract_address from instantiate event*/
     let contract_address = &event
         .attributes
         .iter()
-        .find(|attr| attr.key == "_contract_address")
-        .ok_or_else(|| StdError::generic_err("cannot find `_contract_address` attribute"))?
+        .find(|attr| attr.key == "contract_address")
+        .ok_or_else(|| StdError::generic_err("cannot find `contract_address` attribute"))?
         .value;
 
     /* Update the state of the contract adding the new generated MINTED_TOKEN */
@@ -1390,9 +1390,9 @@ test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; fini
 
 </CH.Scrollycoding>
 
-### 4. Modify `terrain.config.json`
+### 4. Modify `config.terrain.json`
 
-1. Open _`terrain.config.json`_.
+1. Open _`config.terrain.json`_.
 
 2. Modify the property _`InstantiateMsg`_, using your _`<token_contract_code_id>`_. **The _`<token_contract_code_id>`_ should not be surrounded by quotes**.
 


### PR DESCRIPTION
1. `config.terrain.json` is the name generated by terrain, but the cw20 tutorial used `terrain.config.json`.
2. `cw20_factory_token` is named as `cw20-factory-token` in [crates.io](https://crates.io/crates/cw20_factory_token), maybe we should change all naming to `cw20-factory-token` in the tutorial when creating this new contract.
3. `instantiate_contract` and `contract_address` in `test.rs` are named `instantiate` and `_contract_address` in `contract.rs`.
Need to use the same name in `contract.rs` as in `test.rs` to pass unit test. 