### PR TITLE
docs: updating testnet node sync

### DIFF
--- a/docs/full-node/run-a-full-terra-node/build-terra-core.mdx
+++ b/docs/full-node/run-a-full-terra-node/build-terra-core.mdx
@@ -14,13 +14,15 @@ Terra Core is the official Golang reference implementation of the Terra node sof
 
 If you are syncing a node from genesis, you will need to use the appropriate core version for the block height of the respective chain you are syncing. Follow the [sync from genesis](./sync.mdx#sync-from-genesis) guide for step-by-step instructions.
 
-| Network       | Type    | Core Version at Genesis | Fork height        | Core version after fork height                                                                             |
-| :---------------| :------ | :------------------------------------------------------------------------------------------------ | :--------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------- |
-| `phoenix-1`     | Mainnet | v2.0.0                      |  890000                                        | v2.1.1             |
-| `pisco-1`       | Testnet | v2.0.0-rc.0                 |  838500                                        | 2.1.0-beta.1       |
+| Network Name | Network Type | Block Height Range  | Core Version |
+| :----------: | :----------: | :-----------------: | :----------: |
+| `phoenix-1`  |   Mainnet    | `genesis` - 890000  |    v2.0.0    |
+|              |              |  89000 - `present`  |    v2.1.1    |
+|  `pisco-1`   |   Testnet    | `genesis` - 838500  | v2.0.0-rc.0  |
+|              |              |  838500 - 2777777   | 2.1.0-beta.1 |
+|              |              | 2777777 - `present` |    v2.2.0    |
 
 </Admonition>
-
 
 1. Use `git` to retrieve [Terra Core](https://github.com/terra-money/core/), and check out the `main` branch, which contains the latest stable release. You can find the latest tag on the [tags page](https://github.com/terra-money/core/tags) or via autocomplete in your terminal: type `git checkout v` and press `<TAB>`.
 
@@ -53,7 +55,6 @@ If you are syncing a node from genesis, you will need to use the appropriate cor
    go: go version go1.18.2 darwin/amd64
    # ...followed by a lot of dependenecies
    ```
-
 
 <Admonition type="tip" icon="💡">
 

--- a/docs/full-node/run-a-full-terra-node/sync.mdx
+++ b/docs/full-node/run-a-full-terra-node/sync.mdx
@@ -20,7 +20,7 @@ The process for syncing your full node from genesis will differ between the Pisc
 
 ### Pisco testnet
 
-If you would like to sync your node using the Pisco testnet, you will need to utilize version `v2.0.0-rc.0` of terrad up until the block height of 838,500. To sync your node from block 838,500 onward, you will need to utilize version `v2.1.0-beta.1` of terrad. 
+If you would like to sync your node using the Pisco testnet, you will need to utilize version `v2.0.0-rc.0` of terrad up until the block height of 838,500. To sync your node from block 838,500 until block 2,777,777, you will need to utilize version `v2.1.0-beta.1` of terrad. From block 2,777,777 onwards, utilize version `v2.2.0` of terrad.
 
 1. To switch to version `v2.0.0-rc.0` of terrad, [change into your `core` directory](./build-terra-core.mdx#get-the-terra-core-source-code) and execute the following commands in your terminal:
 
@@ -57,9 +57,9 @@ Nodes take at least an hour to start syncing. This wait time is normal. Before t
 
 </Admonition>
 
-Syncing will halt at block 838,500, at which point you will need to change the version of terrad and then resume the syncing process. 
+Syncing will halt at block 838,500, at which point you will need to change the version of terrad and then resume the syncing process.
 
-5. To sync your Pisco testnet node from block 838,500 to the most recent block, you will need to navigate to the `core` directory and change your terrad version to `v2.1.0-beta.1`.
+5. To sync your Pisco testnet node from block 838,500 to block 2,777,777, you will need to navigate to the `core` directory and change your terrad version to `v2.1.0-beta.1`.
 
 ```
 git checkout v2.1.0-beta.1
@@ -80,11 +80,34 @@ The result of this command should be `v2.1.0`.
 terrad start
 ```
 
+Syncing will halt at block 2,777,777, at which point you will need to change the version of terrad and then resume the syncing process.
+
+7. To sync your Pisco testnet node from block 2,777,777 to the most recent block, you will need to navigate to the `core` directory and change your terrad version to `v2.2.0`.
+
+```
+git checkout v2.2.0
+make install
+```
+
+Again, make sure that you have switched to the correct version of terrad by running the following command:
+
+```
+terrad version
+```
+
+The result of this command should be `v2.2.0`.
+
+8. Again, you can resume the syncing process:
+
+```
+terrad start
+```
+
 From here, you can [monitor the sync](#monitor-the-sync). Make sure to check on your node periodically to ensure optimal performance.
 
 ### Phoenix mainnet
 
-If you would like to sync your node using the Phoenix mainnet, you will need to utilize version `v2.0.0` of terrad up until the block height of 890,000. To sync your node from block 890,000 onward, you will need to utilize version `v2.1.1` of terrad.  
+If you would like to sync your node using the Phoenix mainnet, you will need to utilize version `v2.0.0` of terrad up until the block height of 890,000. To sync your node from block 890,000 onward, you will need to utilize version `v2.1.1` of terrad.
 
 1. To switch to version `v2.0.0` of terrad, [change into your `core` directory](./build-terra-core.mdx#get-the-terra-core-source-code) and execute the following commands in your terminal:
 
@@ -125,7 +148,7 @@ Nodes take at least an hour to start syncing. This wait time is normal. Before t
 
 </Admonition>
 
-Syncing will halt at block 890,000, at which point you will need to change the version of terrad and then resume the syncing process. 
+Syncing will halt at block 890,000, at which point you will need to change the version of terrad and then resume the syncing process.
 
 5. To sync your Phoenix mainnet node from block 890,000 to the most recent block, you will need to navigate to the `core` directory and change your terrad version to `v2.1.1`.
 
@@ -153,7 +176,6 @@ From here, you can [monitor the sync](#monitor-the-sync). Make sure to check on 
 <details> 
 <summary> Healthy Node Status Example </summary>
 <p>
-
 
 ```json
 {
@@ -241,7 +263,7 @@ Example of a removed private key:
 
 </Admonition>
 
-If you have an address book downloaded, you may keep it. Otherwise, you will need to download the [appropriate addressbook](./join-a-network.mdx#join-a-public-network).  
+If you have an address book downloaded, you may keep it. Otherwise, you will need to download the [appropriate addressbook](./join-a-network.mdx#join-a-public-network).
 
 With an address book downloaded, run the following:
 
@@ -267,8 +289,6 @@ Your node is catching up with the network by replaying all the transactions from
 
 Compare this height to the **Latest Blocks** by checking the API for the latest block heights on [Phoenix](https://phoenix-lcd.terra.dev/blocks/latest), or [Pisco](https://pisco-lcd.terra.dev/blocks/latest) to see your progress.
 
-
-
 ## Sync complete
 
 You can tell that your node is in sync with the network when `SyncInfo.catching_up` in the `terrad status` response returns `false` and the `latest_block_height` corresponds to the public network blockheight found on the API for either [Phoenix](https://phoenix-lcd.terra.dev/blocks/latest), or [Pisco](https://pisco-lcd.terra.dev/blocks/latest).
@@ -291,8 +311,6 @@ terrad status
 
 Validators can view the status of the network using [Terra Finder](https://finder.terra.money).
 
-
 ## Congratulations!
 
 You've successfully joined a network as a full node operator. If you are a validator, continue to [manage a Terra validator](../manage-a-terra-validator/README.mdx) for next steps.
-


### PR DESCRIPTION
Updating testnet node sync instructions.  From block 2,777,777, we now use terrad version v2.2.0.