### PR TITLE
Update navbar scroll

### DIFF
--- a/src/styles/asideMenu.scss
+++ b/src/styles/asideMenu.scss
@@ -39,7 +39,7 @@
 }
 
 .theme-doc-sidebar-container {
-  height: calc(100% + 420px);
+  height: unset;
 }
 
 li[class*=' theme-doc-sidebar-item-'] {


### PR DESCRIPTION
The current navbar is set to only show 100% of the current window height, meaning most of the menu items can get cut off and become inaccessible. 



In the pic below, you can see everything the governance spec is cut off and can't be accessed. 

<img width="414" alt="Screen Shot 2023-02-21 at 1 17 29 PM" src="https://user-images.githubusercontent.com/87997759/220462144-71bd8ba8-6d9f-49f0-a676-f867639cd6a5.png">

I've reverted this back to having a scroll bar. 

<img width="414" alt="Screen Shot 2023-02-21 at 1 28 17 PM" src="https://user-images.githubusercontent.com/87997759/220462516-8a424815-cf94-4572-a89c-a4cc303f13f3.png">


