### PR TITLE
fix terrain generate ts client command

### DIFF
--- a/docs/develop/terrain/using-terrain-localterra.mdx
+++ b/docs/develop/terrain/using-terrain-localterra.mdx
@@ -150,7 +150,7 @@ Terrain 0.5.x and above includes the ability to automatically generate a TypeScr
 Generating a client is easy, just run the following command in your terminal.
 
 ```
-terrain contract:generateClient my_terra_dapp --build-schema
+terrain contract:generateClient my_terra_dapp
 ```
 
 The client will be generated in `./lib/clients` and copied into the frontend directory.

--- a/docs/develop/terrain/using-terrain-testnet.mdx
+++ b/docs/develop/terrain/using-terrain-testnet.mdx
@@ -98,7 +98,7 @@ Terrain 0.5.x and above includes the ability to automatically generate a TypeScr
 You can generate a client by running the following command in your terminal.
 
 ```
-terrain contract:generateClient my_terra_dapp --build-schema
+terrain contract:generateClient my_terra_dapp
 ```
 
 The client will be generated in `./lib/clients` and copied into the frontend directory.


### PR DESCRIPTION
`--build-schema` flag was removed in a [recent terrain PR](https://github.com/terra-money/terrain/pull/143), reflect that in the doc so people won't have issue generating ts client.